### PR TITLE
Vincent

### DIFF
--- a/packages/mangrove.js/test/scripts/printOrderBook.ts
+++ b/packages/mangrove.js/test/scripts/printOrderBook.ts
@@ -1,5 +1,6 @@
 import { Mangrove } from "../../src";
 import type { Offer } from "../../src/types";
+import type { BookOptions } from "../../src/types";
 import chalk from "chalk";
 import yargs from "yargs";
 
@@ -15,14 +16,23 @@ const argv = yargs(process.argv.slice(2))
     describe: "the name of the quote token (WETH, DAI, USDC, ...)",
     type: "string",
   })
+  .positional("quote", {
+    demandOption: true,
+    describe: "the max number of offers to display",
+    type: "string",
+  })
   .help().argv;
 
 const main = async () => {
-  const mangrove = await Mangrove.connect(process.env["ETHEREUM_NODE_URL"]);
-  const [baseTokenName, quoteTokenName] = argv["_"];
+  const mangrove = await Mangrove.connect(process.env["MUMBAI_NODE_URL"]); // changed ETHEREUM_ to MUMBAI_
+  const [baseTokenName, quoteTokenName, maxOffersDisplayed] = argv["_"];
+  const numberOffersDisplayed = {
+    maxOffers: maxOffersDisplayed,
+  }; // added an arg to define the number of offers to display
   const market = await mangrove.market({
     base: baseTokenName,
     quote: quoteTokenName,
+    bookOptions: numberOffersDisplayed,
   });
   const { asks, bids } = market.book();
 

--- a/packages/mangrove.js/test/scripts/printOrderBook.ts
+++ b/packages/mangrove.js/test/scripts/printOrderBook.ts
@@ -5,7 +5,9 @@ import chalk from "chalk";
 import yargs from "yargs";
 
 const argv = yargs(process.argv.slice(2))
-  .usage("Usage: ts-node $0 <base token name> <quote token name>")
+  .usage(
+    "Usage: ts-node $0 <base token name> <quote token name> <max offers displayed>"
+  )
   .positional("base", {
     demandOption: true,
     describe: "the name of the base token (WETH, DAI, USDC, ...)",
@@ -16,24 +18,36 @@ const argv = yargs(process.argv.slice(2))
     describe: "the name of the quote token (WETH, DAI, USDC, ...)",
     type: "string",
   })
-  .positional("quote", {
-    demandOption: true,
+  .positional("maxOffers", {
+    //demandOption: true,
     describe: "the max number of offers to display",
     type: "string",
+    //default: 10,
   })
   .help().argv;
+//console.log(argv);
+//console.log(argv["_"]);
 
 const main = async () => {
-  const mangrove = await Mangrove.connect(process.env["MUMBAI_NODE_URL"]); // changed ETHEREUM_ to MUMBAI_
-  const [baseTokenName, quoteTokenName, maxOffersDisplayed] = argv["_"];
-  const numberOffersDisplayed = {
+  // changed ETHEREUM_ to MUMBAI_
+  const mangrove = await Mangrove.connect(process.env["MUMBAI_NODE_URL"]);
+  // added an optional argument to define the number of offers to display
+  let [baseTokenName, quoteTokenName, maxOffersDisplayed] = argv["_"];
+  // if undefined by the command line we set it to default value 10
+  if (typeof maxOffersDisplayed == "undefined") {
+    maxOffersDisplayed = 10;
+  }
+
+  let numberOffersDisplayed = {
     maxOffers: maxOffersDisplayed,
-  }; // added an arg to define the number of offers to display
+  };
+
   const market = await mangrove.market({
     base: baseTokenName,
     quote: quoteTokenName,
     bookOptions: numberOffersDisplayed,
   });
+
   const { asks, bids } = market.book();
 
   console.group("MARKET");

--- a/packages/mangrove.js/test/scripts/printOrderBook.ts
+++ b/packages/mangrove.js/test/scripts/printOrderBook.ts
@@ -1,12 +1,11 @@
 import { Mangrove } from "../../src";
 import type { Offer } from "../../src/types";
-import type { BookOptions } from "../../src/types";
 import chalk from "chalk";
 import yargs from "yargs";
 
 const argv = yargs(process.argv.slice(2))
   .usage(
-    "Usage: ts-node $0 <base token name> <quote token name> <max offers displayed>"
+    "Usage: ts-node $0 <base token name> <quote token name> [max offers displayed]"
   )
   .positional("base", {
     demandOption: true,
@@ -19,21 +18,18 @@ const argv = yargs(process.argv.slice(2))
     type: "string",
   })
   .positional("maxOffers", {
-    //demandOption: true,
     describe: "the max number of offers to display",
     type: "string",
-    //default: 10,
   })
   .help().argv;
-//console.log(argv);
-//console.log(argv["_"]);
 
 const main = async () => {
   // changed ETHEREUM_ to MUMBAI_
-  const mangrove = await Mangrove.connect(process.env["MUMBAI_NODE_URL"]);
+  const mangrove = await Mangrove.connect(process.env["NODE_URL"]);
   // added an optional argument to define the number of offers to display
   let [baseTokenName, quoteTokenName, maxOffersDisplayed] = argv["_"];
   // if undefined by the command line we set it to default value 10
+  // FIXME there should be a way to set a default value using yargs
   if (typeof maxOffersDisplayed == "undefined") {
     maxOffersDisplayed = 10;
   }


### PR DESCRIPTION
I modified the script `mangrove.js/test/scripts/printOrderBook.ts` so that one can now pass a third argument to specify the max number of offers to be displayed by the script (the default set in `market.ts` was 50)

If the user does not specify the third argument the default value is 10. 