### PR TITLE
mangrove-solidity: Add static CNAME to doc

### DIFF
--- a/packages/mangrove-solidity/doc/CNAME
+++ b/packages/mangrove-solidity/doc/CNAME
@@ -1,0 +1,1 @@
+code.mangrove.exchange


### PR DESCRIPTION
GitHub habitually clobbers a dynamically configured CNAME
https://github.com/tschaub/gh-pages/issues/236