### PR TITLE
mangrove.js: Improve CLI useability

### DIFF
--- a/packages/mangrove.js/CHANGELOG.md
+++ b/packages/mangrove.js/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next version
 
+- Add experimental CLI: `mgv`. See README.md for instructions
+
 # 0.0.9 (January 2022)
 
 - New Mangrove deployment

--- a/packages/mangrove.js/README.md
+++ b/packages/mangrove.js/README.md
@@ -318,3 +318,30 @@ $ yarn build
 ```
 
 The build artifacts will be placed in `./dist/nodejs` and `./dist/browser`.
+
+## CLI: `mgv`
+
+mangrove.js includes an experimental command line interface (CLI) for interacting with Mangrove.
+You can run it using `npx`, `yarn`, or directly (if you install mangrove.js globally):
+
+```shell
+$ npx mgv
+$ yarn mgv
+$ mgv         # requires mangrove.js to be installed globally: npm -g install mangrove.js
+mgv.js <command>
+
+Commands:
+  mgv.js parrot                  reports the current environment and warns of
+                                 any discrepancies       [aliases: env-overview]
+  mgv.js print <base> <quote>    print the offers on a market
+  mgv.js retract <base> <quote>  retracts all offers from the given market
+
+Options:
+  --version  Show version number                                       [boolean]
+  --help     Show help                                                 [boolean]
+
+Arguments may be provided in env vars beginning with 'MGV_'. For example,
+MGV_NODE_URL=https://node.url can be used instead of --nodeUrl https://node.url
+
+You need at least one command before moving on
+```

--- a/packages/mangrove.js/package.json
+++ b/packages/mangrove.js/package.json
@@ -9,10 +9,11 @@
     "precommit": "lint-staged",
     "prepack": "yarn run build",
     "lint": "npx eslint ./src/*.ts",
-    "build-this-package": "yarn run get-mangrove-abis && yarn run typechain && yarn run lint && tsc && yarn run write-test-deployment-file && yarn run copy-static-and-generated-assets && yarn run rollup",
+    "build-this-package": "yarn run get-mangrove-abis && yarn run typechain && yarn run lint && tsc --build src && yarn run make-cli-executable && yarn run write-test-deployment-file && yarn run copy-static-and-generated-assets && yarn run rollup",
     "build": "yarn install && yarn workspaces foreach -vpiR --topological-dev --from $npm_package_name run build-this-package",
     "check-mangrove-abis": "ts-node warnIfDifferent.ts -- node_modules/@mangrovedao/mangrove-solidity/dist/mangrove-abis src/abis \"Warning! Mangrove ABIs in src/abis do not match ABIs in mangrove-solidity\"",
     "get-mangrove-abis": "cp node_modules/@mangrovedao/mangrove-solidity/dist/mangrove-abis/*.json ./src/abis/",
+    "make-cli-executable": "shx chmod u+x ./dist/nodejs/cli/mgv.js",
     "copy-static-and-generated-assets": "ts-node copyStaticAndGeneratedAssets.ts",
     "write-test-deployment-file": "ts-node writeTestDeploymentFiles.ts",
     "clean-this-package": "yarn run clean-typechain && rimraf dist",
@@ -33,7 +34,7 @@
     "README.md"
   ],
   "bin": {
-    "mgv": "./cli/mgv.ts"
+    "mgv": "./dist/nodejs/cli/mgv.js"
   },
   "repository": {
     "type": "git",
@@ -106,6 +107,7 @@
     "rollup-plugin-terser": "^7.0.2",
     "seedrandom": "^3.0.5",
     "shelljs": "^0.8.4",
+    "shx": "^0.3.4",
     "ts-essentials": "^8.1.0",
     "ts-node": "^9.1.1",
     "typechain": "^6.0.2",

--- a/packages/mangrove.js/src/cli/commands/parrotCmd.ts
+++ b/packages/mangrove.js/src/cli/commands/parrotCmd.ts
@@ -1,7 +1,7 @@
 import * as yargs from "yargs";
-import { Mangrove } from "../../src";
+import { Mangrove } from "../..";
 import { fetchJson } from "ethers/lib/utils";
-import packageJson from "../../package.json";
+import packageJson from "../../../package.json";
 import { Big } from "big.js";
 
 export const command = "parrot";
@@ -61,8 +61,8 @@ type MangroveJsEnvironmentInfo = {
   contractAddresses: ContractAddresses;
 };
 type MangroveConfigurationInfo = {
-  globalConfig: Mangrove.globalConfig;
-  localConfigs: { base: string; quote: string; config: Mangrove.localConfig }[];
+  globalConfig: Mangrove.GlobalConfig;
+  localConfigs: { base: string; quote: string; config: Mangrove.LocalConfig }[];
 };
 type MangroveJsAppEnvironmentInfo = {
   url: string;

--- a/packages/mangrove.js/src/cli/commands/printCmd.ts
+++ b/packages/mangrove.js/src/cli/commands/printCmd.ts
@@ -1,6 +1,6 @@
 import * as yargs from "yargs";
 import chalk from "chalk";
-import { Mangrove, Market } from "../../src";
+import { Mangrove, Market } from "../..";
 
 export const command = "print <base> <quote>";
 export const aliases = [];

--- a/packages/mangrove.js/src/cli/commands/retractCmd.ts
+++ b/packages/mangrove.js/src/cli/commands/retractCmd.ts
@@ -4,7 +4,7 @@ import ethers from "ethers";
 import { WebSocketProvider } from "@ethersproject/providers";
 import { Wallet } from "@ethersproject/wallet";
 import { NonceManager } from "@ethersproject/experimental";
-import { Mangrove, Market } from "../../src";
+import { Mangrove, Market } from "../..";
 
 export const command = "retract <base> <quote>";
 export const aliases = [];

--- a/packages/mangrove.js/src/cli/mgv.ts
+++ b/packages/mangrove.js/src/cli/mgv.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env ts-node
+#!/usr/bin/env node
 
 import * as yargs from "yargs";
 import * as parrotCmd from "./commands/parrotCmd";

--- a/packages/mangrove.js/src/tsconfig.json
+++ b/packages/mangrove.js/src/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "module": "CommonJS",
+    "esModuleInterop": true,
+    "outDir": "../dist/nodejs/",
+    "lib": ["ES2020", "dom"],
+    "resolveJsonModule": true,
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "declaration": true,
+    "noErrorTruncation": true,
+    "target": "es2015",
+    "incremental":true
+    //"strict": true,
+    //"suppressImplicitAnyIndexErrors": true,
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.d.ts"
+  ],
+  "references": [
+    { "path": "../" }
+  ]
+}

--- a/packages/mangrove.js/tsconfig.json
+++ b/packages/mangrove.js/tsconfig.json
@@ -2,20 +2,15 @@
   "compilerOptions": {
     "module": "CommonJS",
     "esModuleInterop": true,
-    "outDir": "dist/nodejs/",
     "lib": ["ES2020", "dom"],
     "resolveJsonModule": true,
     "moduleResolution": "node",
-    "sourceMap": true,
-    "declaration": true,
-    "noErrorTruncation": true,
     "target": "es2015",
-    "incremental":true
-    //"strict": true,
-    //"suppressImplicitAnyIndexErrors": true,
+    "rootDir": ".",
+    "outDir": "./dist",  // if out path for a file is same as its src path, nothing will be emitted
+    "composite": true  // required on the dependency project for references to work
   },
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.d.ts"
+  "files": [         // by whitelisting the files to include, TS won't automatically
+    "package.json"   // include all source below root, which is the default.
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1229,6 +1229,7 @@ __metadata:
     rollup-plugin-terser: ^7.0.2
     seedrandom: ^3.0.5
     shelljs: ^0.8.4
+    shx: ^0.3.4
     ts-essentials: ^8.1.0
     ts-node: ^9.1.1
     typechain: ^6.0.2
@@ -1236,7 +1237,7 @@ __metadata:
     typescript: ^4.4.0
     yargs: ^17.3.0
   bin:
-    mgv: ./cli/mgv.ts
+    mgv: ./dist/nodejs/cli/mgv.js
   languageName: unknown
   linkType: soft
 
@@ -8722,6 +8723,19 @@ resolve@1.17.0:
   languageName: node
   linkType: hard
 
+"shelljs@npm:^0.8.5":
+  version: 0.8.5
+  resolution: "shelljs@npm:0.8.5"
+  dependencies:
+    glob: ^7.0.0
+    interpret: ^1.0.0
+    rechoir: ^0.6.2
+  bin:
+    shjs: bin/shjs
+  checksum: 7babc46f732a98f4c054ec1f048b55b9149b98aa2da32f6cf9844c434b43c6251efebd6eec120937bd0999e13811ebd45efe17410edb3ca938f82f9381302748
+  languageName: node
+  linkType: hard
+
 "shiki@npm:^0.9.12":
   version: 0.9.12
   resolution: "shiki@npm:0.9.12"
@@ -8730,6 +8744,18 @@ resolve@1.17.0:
     onigasm: ^2.2.5
     vscode-textmate: 5.2.0
   checksum: ee2ca7b997ffe6d412af946c7fa3909f2ade3fe505fe03b5c3f3c5cc90a9b10dbe34a208c9557ee0376d7a64c23995445cdb7c69e60da855cf80305bafdc018e
+  languageName: node
+  linkType: hard
+
+"shx@npm:^0.3.4":
+  version: 0.3.4
+  resolution: "shx@npm:0.3.4"
+  dependencies:
+    minimist: ^1.2.3
+    shelljs: ^0.8.5
+  bin:
+    shx: lib/cli.js
+  checksum: 0aa168bfddc11e3fe8943cce2e0d2d8514a560bd58cf2b835b4351ba03f46068f7d88286c2627f4b85604e81952154c43746369fb3f0d60df0e3b511f465e5b8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The CLI is now compiled and can be run without ts-node.
This also means that CI will complain if we forget to update it.

As the CLI includes package.json, we've had to move tsconfig.json to src/ and introduce a simpler one in the root of mangrove.js. Otherwise, the compiled files would be placed in dist/nodejs/src.
See the following link for more information: https://stackoverflow.com/a/61467483/16614325