### PR TITLE
feat(market): Add options for initially loading offers matching desired volume or price

### DIFF
--- a/packages/mangrove.js/CHANGELOG.md
+++ b/packages/mangrove.js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next version
 
+- New `Market` options:
+  - `desiredPrice`: allows one to specify a price point of interest. This will cause the cache to initially load all offers with this price or better.
+  - `desiredVolume`: allows one to specify a volume of interest. This will cause the cache to initially load at least this volume (if available). The option uses the same specification as for `estimateVolume`: `desiredVolume: { given: 1, what: "base", to: "buy" }` will cause the asks semibook to be initialized with a volume of at least 1 base token.
+
 # 0.1.0 (January 2022)
 
 - `{Market|Semibook}.getPivotId` now fetches offers until a pivot can be determined

--- a/packages/mangrove.js/README.md
+++ b/packages/mangrove.js/README.md
@@ -45,7 +45,7 @@ const mgv = await Mangrove.connect({
 ## Obtaining a market object
 
 ```js
-  // Connect to ETHUSDC market
+  // Connect to ETH-USDC market
   const market = mgv.market({ base: "ETH", quote: "USDC" });
 
   // Check allowance

--- a/packages/mangrove.js/src/market.ts
+++ b/packages/mangrove.js/src/market.ts
@@ -532,7 +532,7 @@ class Market {
   }
 
   /**
-   * Volume estimator, very crude (based on cached book).
+   * Volume estimator.
    *
    * if you say `estimateVolume({given:100,what:"base",to:"buy"})`,
    *

--- a/packages/mangrove.js/src/market.ts
+++ b/packages/mangrove.js/src/market.ts
@@ -45,8 +45,13 @@ namespace Market {
     | { wants: Bigish; gives: Bigish; fillWants?: boolean }
   );
 
+  /**
+   * Options that control how the book cache behaves.
+   */
   export type BookOptions = {
+    /** The maximum number of offers to store in the cache. */
     maxOffers?: number;
+    /** The number of offers to fetch in one call. Defaults to max(`maxOffers`, 1). */
     chunkSize?: number;
   };
 

--- a/packages/mangrove.js/src/market.ts
+++ b/packages/mangrove.js/src/market.ts
@@ -4,7 +4,7 @@ import { Bigish, typechain } from "./types";
 import Mangrove from "./mangrove";
 import MgvToken from "./mgvtoken";
 import { OrderCompleteEvent } from "./types/typechain/Mangrove";
-import { Semibook, SemibookEvent } from "./semibook";
+import Semibook from "./semibook";
 
 let canConstructMarket = false;
 
@@ -224,7 +224,7 @@ class Market {
     cbArg,
     event,
     ethersLog: ethersLog,
-  }: SemibookEvent): void {
+  }: Semibook.Event): void {
     this.#updateBook(cbArg.ba);
     for (const [cb, params] of this.#subscriptions) {
       if (params.type === "once") {

--- a/packages/mangrove.js/src/semibook.ts
+++ b/packages/mangrove.js/src/semibook.ts
@@ -19,6 +19,16 @@ namespace Semibook {
   };
 
   export type EventListener = (e: Event) => void;
+
+  /**
+   * Options that control how the book cache behaves.
+   */
+  export type Options = {
+    /** The maximum number of offers to store in the cache. */
+    maxOffers?: number;
+    /** The number of offers to fetch in one call. Defaults to max(`maxOffers`, 1). */
+    chunkSize?: number;
+  };
 }
 
 type RawOfferData = {
@@ -47,7 +57,7 @@ type RawOfferData = {
 class Semibook implements Iterable<Market.Offer> {
   readonly ba: "bids" | "asks";
   readonly market: Market;
-  readonly options: Market.BookOptions; // complete and validated
+  readonly options: Semibook.Options; // complete and validated
 
   // TODO: Why is only the gasbase stored as part of the semibook? Why not the rest of the local configuration?
   #offer_gasbase: number;
@@ -68,7 +78,7 @@ class Semibook implements Iterable<Market.Offer> {
     market: Market,
     ba: "bids" | "asks",
     eventListener: Semibook.EventListener,
-    options: Market.BookOptions
+    options: Semibook.Options
   ): Promise<Semibook> {
     canConstructSemibook = true;
     const semibook = new Semibook(market, ba, eventListener, options);
@@ -83,7 +93,7 @@ class Semibook implements Iterable<Market.Offer> {
   }
 
   async requestOfferListPrefix(
-    options: Market.BookOptions
+    options: Semibook.Options
   ): Promise<Market.Offer[]> {
     return await this.#fetchOfferListPrefix(
       await this.market.mgv._provider.getBlockNumber(),
@@ -332,7 +342,7 @@ class Semibook implements Iterable<Market.Offer> {
     market: Market,
     ba: "bids" | "asks",
     eventListener: Semibook.EventListener,
-    options: Market.BookOptions
+    options: Semibook.Options
   ) {
     if (!canConstructSemibook) {
       throw Error(
@@ -597,7 +607,7 @@ class Semibook implements Iterable<Market.Offer> {
   async #fetchOfferListPrefix(
     blockNumber: number,
     fromId?: number,
-    options?: Market.BookOptions
+    options?: Semibook.Options
   ): Promise<Market.Offer[]> {
     const opts = this.#setDefaultsAndValidateOptions({
       ...this.options,
@@ -720,9 +730,7 @@ class Semibook implements Iterable<Market.Offer> {
     };
   }
 
-  #setDefaultsAndValidateOptions(
-    options: Market.BookOptions
-  ): Market.BookOptions {
+  #setDefaultsAndValidateOptions(options: Semibook.Options): Semibook.Options {
     const result = { ...bookOptsDefault, ...options };
     if (result.chunkSize === undefined) {
       result.chunkSize =

--- a/packages/mangrove.js/src/semibook.ts
+++ b/packages/mangrove.js/src/semibook.ts
@@ -10,13 +10,16 @@ import { Listener } from "@ethersproject/providers";
 // Guard constructor against external calls
 let canConstructSemibook = false;
 
-export type SemibookEvent = {
-  cbArg: Market.BookSubscriptionCbArgument;
-  event: Market.BookSubscriptionEvent;
-  ethersLog: ethers.providers.Log;
-};
+// eslint-disable-next-line @typescript-eslint/no-namespace
+namespace Semibook {
+  export type Event = {
+    cbArg: Market.BookSubscriptionCbArgument;
+    event: Market.BookSubscriptionEvent;
+    ethersLog: ethers.providers.Log;
+  };
 
-export type SemibookEventListener = (e: SemibookEvent) => void;
+  export type EventListener = (e: Event) => void;
+}
 
 type RawOfferData = {
   id: BigNumber;
@@ -41,7 +44,7 @@ type RawOfferData = {
  * - Volumes are in terms of base tokens
  */
 // TODO: Document invariants
-export class Semibook implements Iterable<Market.Offer> {
+class Semibook implements Iterable<Market.Offer> {
   readonly ba: "bids" | "asks";
   readonly market: Market;
   readonly options: Market.BookOptions; // complete and validated
@@ -53,7 +56,7 @@ export class Semibook implements Iterable<Market.Offer> {
 
   #blockEventCallback: Listener;
   #eventFilter: TypedEventFilter<any>;
-  #eventListener: SemibookEventListener;
+  #eventListener: Semibook.EventListener;
 
   #cacheLock: Mutex; // Lock that must be acquired when modifying the cache to ensure consistency and to queue cache updating events.
   #offerCache: Map<number, Market.Offer>; // NB: Modify only via #insertOffer and #removeOffer to ensure cache consistency
@@ -64,7 +67,7 @@ export class Semibook implements Iterable<Market.Offer> {
   static async connect(
     market: Market,
     ba: "bids" | "asks",
-    eventListener: SemibookEventListener,
+    eventListener: Semibook.EventListener,
     options: Market.BookOptions
   ): Promise<Semibook> {
     canConstructSemibook = true;
@@ -328,7 +331,7 @@ export class Semibook implements Iterable<Market.Offer> {
   private constructor(
     market: Market,
     ba: "bids" | "asks",
-    eventListener: SemibookEventListener,
+    eventListener: Semibook.EventListener,
     options: Market.BookOptions
   ) {
     if (!canConstructSemibook) {

--- a/packages/mangrove.js/test/integration/semibook.integration.test.ts
+++ b/packages/mangrove.js/test/integration/semibook.integration.test.ts
@@ -481,5 +481,207 @@ describe("Semibook integration tests suite", () => {
         expect(semibook.size()).to.equal(3);
       });
     });
+
+    describe("Option.desiredVolume", () => {
+      describe("{to: buy}", () => {
+        it("does not fail if offer list is empty", async function () {
+          const market = await mgv.market({
+            base: "TokenA",
+            quote: "TokenB",
+            bookOptions: {
+              desiredVolume: {
+                given: 1,
+                what: "base",
+                to: "buy",
+              },
+              chunkSize: 1, // Fetch only 1 offer in each chunk
+            },
+          });
+          const semibook = market.getSemibook("asks");
+          expect(semibook.size()).to.equal(0);
+        });
+
+        it("fetches all offers if offer list has insufficient volume", async function () {
+          await waitForTransaction(
+            newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "1" })
+          );
+          await waitForTransaction(
+            newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "2" })
+          );
+          await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
+
+          const market = await mgv.market({
+            base: "TokenA",
+            quote: "TokenB",
+            bookOptions: {
+              desiredVolume: {
+                given: 3,
+                what: "base",
+                to: "buy",
+              },
+              chunkSize: 1, // Fetch only 1 offer in each chunk
+            },
+          });
+          const semibook = market.getSemibook("asks");
+          expect(semibook.size()).to.equal(2);
+        });
+
+        it("fetches only one chunk if it has sufficient volume", async function () {
+          await waitForTransaction(
+            newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "1" })
+          );
+          await waitForTransaction(
+            newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "2" })
+          );
+          await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
+
+          const market = await mgv.market({
+            base: "TokenA",
+            quote: "TokenB",
+            bookOptions: {
+              desiredVolume: {
+                given: 1,
+                what: "base",
+                to: "buy",
+              },
+              chunkSize: 1, // Fetch only 1 offer in each chunk
+            },
+          });
+          const semibook = market.getSemibook("asks");
+          expect(semibook.size()).to.equal(1);
+        });
+
+        it("stops fetching when sufficient volume has been fetched", async function () {
+          await waitForTransaction(
+            newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "1" })
+          );
+          await waitForTransaction(
+            newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "2" })
+          );
+          await waitForTransaction(
+            newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "3" })
+          );
+          await waitForTransaction(
+            newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "4" })
+          );
+          await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
+
+          const market = await mgv.market({
+            base: "TokenA",
+            quote: "TokenB",
+            bookOptions: {
+              desiredVolume: {
+                given: 3,
+                what: "base",
+                to: "buy",
+              },
+              chunkSize: 1, // Fetch only 1 offer in each chunk
+            },
+          });
+          const semibook = market.getSemibook("asks");
+          expect(semibook.size()).to.equal(3);
+        });
+      });
+
+      describe("{to: sell}", () => {
+        it("does not fail if offer list is empty", async function () {
+          const market = await mgv.market({
+            base: "TokenA",
+            quote: "TokenB",
+            bookOptions: {
+              desiredVolume: {
+                given: 1,
+                what: "quote",
+                to: "sell",
+              },
+              chunkSize: 1, // Fetch only 1 offer in each chunk
+            },
+          });
+          const semibook = market.getSemibook("asks");
+          expect(semibook.size()).to.equal(0);
+        });
+
+        it("fetches all offers if offer list has insufficient volume", async function () {
+          await waitForTransaction(
+            newOffer(mgv, "TokenA", "TokenB", { gives: "2", wants: "1" })
+          );
+          await waitForTransaction(
+            newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "1" })
+          );
+          await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
+
+          const market = await mgv.market({
+            base: "TokenA",
+            quote: "TokenB",
+            bookOptions: {
+              desiredVolume: {
+                given: 3,
+                what: "quote",
+                to: "sell",
+              },
+              chunkSize: 1, // Fetch only 1 offer in each chunk
+            },
+          });
+          const semibook = market.getSemibook("asks");
+          expect(semibook.size()).to.equal(2);
+        });
+
+        it("fetches only one chunk if it has sufficient volume", async function () {
+          await waitForTransaction(
+            newOffer(mgv, "TokenA", "TokenB", { gives: "2", wants: "1" })
+          );
+          await waitForTransaction(
+            newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "1" })
+          );
+          await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
+
+          const market = await mgv.market({
+            base: "TokenA",
+            quote: "TokenB",
+            bookOptions: {
+              desiredVolume: {
+                given: 1,
+                what: "quote",
+                to: "sell",
+              },
+              chunkSize: 1, // Fetch only 1 offer in each chunk
+            },
+          });
+          const semibook = market.getSemibook("asks");
+          expect(semibook.size()).to.equal(1);
+        });
+
+        it("stops fetching when sufficient volume has been fetched", async function () {
+          await waitForTransaction(
+            newOffer(mgv, "TokenA", "TokenB", { gives: "4", wants: "1" })
+          );
+          await waitForTransaction(
+            newOffer(mgv, "TokenA", "TokenB", { gives: "3", wants: "1" })
+          );
+          await waitForTransaction(
+            newOffer(mgv, "TokenA", "TokenB", { gives: "2", wants: "1" })
+          );
+          await waitForTransaction(
+            newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "1" })
+          );
+          await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
+
+          const market = await mgv.market({
+            base: "TokenA",
+            quote: "TokenB",
+            bookOptions: {
+              desiredVolume: {
+                given: 3,
+                what: "quote",
+                to: "sell",
+              },
+              chunkSize: 1, // Fetch only 1 offer in each chunk
+            },
+          });
+          const semibook = market.getSemibook("asks");
+          expect(semibook.size()).to.equal(3);
+        });
+      });
+    });
   });
 });

--- a/packages/mangrove.js/test/integration/semibook.integration.test.ts
+++ b/packages/mangrove.js/test/integration/semibook.integration.test.ts
@@ -132,257 +132,267 @@ describe("Semibook integration tests suite", () => {
     });
   });
 
-  (["buy", "sell"] as const).forEach((to) =>
-    describe(`estimateVolume({to: ${to}}) - cache tests`, () => {
-      it("returns all given as residue when cache and offer list is empty", async function () {
+  describe("estimateVolume", () => {
+    (["buy", "sell"] as const).forEach((to) =>
+      describe(`estimateVolume({to: ${to}}) - cache tests`, () => {
+        it("returns all given as residue when cache and offer list is empty", async function () {
+          const market = await mgv.market({ base: "TokenA", quote: "TokenB" });
+          const semibook = market.getSemibook("asks");
+          expect(await semibook.estimateVolume({ given: 1, to })).to.deep.equal(
+            {
+              estimatedVolume: Big(0),
+              givenResidue: Big(1),
+            }
+          );
+        });
+
+        it("returns correct estimate and residue when cache is empty and offer list is not", async function () {
+          // Put one offer on asks
+          await waitForTransaction(
+            newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "1" })
+          );
+          await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
+
+          // Load no offers in cache
+          const market = await mgv.market({
+            base: "TokenA",
+            quote: "TokenB",
+            bookOptions: { maxOffers: 0 },
+          });
+          const semibook = market.getSemibook("asks");
+          expect(await semibook.estimateVolume({ given: 1, to })).to.deep.equal(
+            {
+              estimatedVolume: Big(1),
+              givenResidue: Big(0),
+            }
+          );
+        });
+
+        it("returns correct estimate and residue when cache is partial and insufficient while offer list is sufficient", async function () {
+          // Put one offer on asks
+          await waitForTransaction(
+            newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "1" })
+          );
+          await waitForTransaction(
+            newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "1" })
+          );
+          await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
+
+          // Load 1 offer in cache
+          const market = await mgv.market({
+            base: "TokenA",
+            quote: "TokenB",
+            bookOptions: { maxOffers: 1 },
+          });
+          const semibook = market.getSemibook("asks");
+          expect(await semibook.estimateVolume({ given: 2, to })).to.deep.equal(
+            {
+              estimatedVolume: Big(2),
+              givenResidue: Big(0),
+            }
+          );
+        });
+
+        it("returns correct estimate and residue when cache is partial and offer list is insufficient", async function () {
+          // Put one offer on asks
+          await waitForTransaction(
+            newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "1" })
+          );
+          await waitForTransaction(
+            newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "1" })
+          );
+          await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
+
+          // Load 1 offer in cache
+          const market = await mgv.market({
+            base: "TokenA",
+            quote: "TokenB",
+            bookOptions: { maxOffers: 1 },
+          });
+          const semibook = market.getSemibook("asks");
+          expect(await semibook.estimateVolume({ given: 3, to })).to.deep.equal(
+            {
+              estimatedVolume: Big(2),
+              givenResidue: Big(1),
+            }
+          );
+        });
+      })
+    );
+
+    describe("estimateVolume({to: buy}) - calculation tests", () => {
+      it("returns zero when given is zero", async function () {
+        await waitForTransaction(
+          newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "2" })
+        );
+
+        await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
         const market = await mgv.market({ base: "TokenA", quote: "TokenB" });
         const semibook = market.getSemibook("asks");
-        expect(await semibook.estimateVolume({ given: 1, to })).to.deep.equal({
+        expect(
+          await semibook.estimateVolume({ given: 0, to: "buy" })
+        ).to.deep.equal({
           estimatedVolume: Big(0),
+          givenResidue: Big(0),
+        });
+      });
+
+      it("estimates all available volume when offer list has 1 offer with insufficient volume", async function () {
+        await waitForTransaction(
+          newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "2" })
+        );
+        await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
+
+        const market = await mgv.market({ base: "TokenA", quote: "TokenB" });
+        const semibook = market.getSemibook("asks");
+        expect(
+          await semibook.estimateVolume({ given: 2, to: "buy" })
+        ).to.deep.equal({
+          estimatedVolume: Big(2),
           givenResidue: Big(1),
         });
       });
 
-      it("returns correct estimate and residue when cache is empty and offer list is not", async function () {
-        // Put one offer on asks
+      it("estimates all available volume when offer list has multiple offers with insufficient volume", async function () {
         await waitForTransaction(
-          newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "1" })
+          newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "2" })
+        );
+        await waitForTransaction(
+          newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "3" })
         );
         await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
 
-        // Load no offers in cache
-        const market = await mgv.market({
-          base: "TokenA",
-          quote: "TokenB",
-          bookOptions: { maxOffers: 0 },
-        });
+        const market = await mgv.market({ base: "TokenA", quote: "TokenB" });
         const semibook = market.getSemibook("asks");
-        expect(await semibook.estimateVolume({ given: 1, to })).to.deep.equal({
+        expect(
+          await semibook.estimateVolume({ given: 3, to: "buy" })
+        ).to.deep.equal({
+          estimatedVolume: Big(5),
+          givenResidue: Big(1),
+        });
+      });
+
+      it("estimates volume and no residue when offer list has 1 offer with sufficient volume", async function () {
+        await waitForTransaction(
+          newOffer(mgv, "TokenA", "TokenB", { gives: "2", wants: "4" })
+        );
+        await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
+
+        const market = await mgv.market({ base: "TokenA", quote: "TokenB" });
+        const semibook = market.getSemibook("asks");
+        expect(
+          await semibook.estimateVolume({ given: 1, to: "buy" })
+        ).to.deep.equal({
+          estimatedVolume: Big(2),
+          givenResidue: Big(0),
+        });
+      });
+
+      it("estimates volume and no residue when offer list has multiple offers which together have sufficient volume", async function () {
+        await waitForTransaction(
+          newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "2" })
+        );
+        await waitForTransaction(
+          newOffer(mgv, "TokenA", "TokenB", { gives: "2", wants: "4" })
+        );
+        await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
+
+        const market = await mgv.market({ base: "TokenA", quote: "TokenB" });
+        const semibook = market.getSemibook("asks");
+        expect(
+          await semibook.estimateVolume({ given: 2, to: "buy" })
+        ).to.deep.equal({
+          estimatedVolume: Big(4),
+          givenResidue: Big(0),
+        });
+      });
+    });
+
+    describe("estimateVolume({to: sell}) - calculation tests", () => {
+      it("returns zero when given is zero", async function () {
+        await waitForTransaction(
+          newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "2" })
+        );
+
+        await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
+        const market = await mgv.market({ base: "TokenA", quote: "TokenB" });
+        const semibook = market.getSemibook("asks");
+        expect(
+          await semibook.estimateVolume({ given: 0, to: "sell" })
+        ).to.deep.equal({
+          estimatedVolume: Big(0),
+          givenResidue: Big(0),
+        });
+      });
+
+      it("estimates all available volume when offer list has 1 offer with insufficient volume", async function () {
+        await waitForTransaction(
+          newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "2" })
+        );
+        await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
+
+        const market = await mgv.market({ base: "TokenA", quote: "TokenB" });
+        const semibook = market.getSemibook("asks");
+        expect(
+          await semibook.estimateVolume({ given: 3, to: "sell" })
+        ).to.deep.equal({
+          estimatedVolume: Big(1),
+          givenResidue: Big(1),
+        });
+      });
+
+      it("estimates all available volume when offer list has multiple offers with insufficient volume", async function () {
+        await waitForTransaction(
+          newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "2" })
+        );
+        await waitForTransaction(
+          newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "3" })
+        );
+        await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
+
+        const market = await mgv.market({ base: "TokenA", quote: "TokenB" });
+        const semibook = market.getSemibook("asks");
+        expect(
+          await semibook.estimateVolume({ given: 6, to: "sell" })
+        ).to.deep.equal({
+          estimatedVolume: Big(2),
+          givenResidue: Big(1),
+        });
+      });
+
+      it("estimates volume and no residue when offer list has 1 offer with sufficient volume", async function () {
+        await waitForTransaction(
+          newOffer(mgv, "TokenA", "TokenB", { gives: "2", wants: "4" })
+        );
+        await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
+
+        const market = await mgv.market({ base: "TokenA", quote: "TokenB" });
+        const semibook = market.getSemibook("asks");
+        expect(
+          await semibook.estimateVolume({ given: 2, to: "sell" })
+        ).to.deep.equal({
           estimatedVolume: Big(1),
           givenResidue: Big(0),
         });
       });
 
-      it("returns correct estimate and residue when cache is partial and insufficient while offer list is sufficient", async function () {
-        // Put one offer on asks
+      it("estimates volume and no residue when offer list has multiple offers which together have sufficient volume", async function () {
         await waitForTransaction(
-          newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "1" })
+          newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "2" })
         );
         await waitForTransaction(
-          newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "1" })
+          newOffer(mgv, "TokenA", "TokenB", { gives: "2", wants: "4" })
         );
         await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
 
-        // Load 1 offer in cache
-        const market = await mgv.market({
-          base: "TokenA",
-          quote: "TokenB",
-          bookOptions: { maxOffers: 1 },
-        });
+        const market = await mgv.market({ base: "TokenA", quote: "TokenB" });
         const semibook = market.getSemibook("asks");
-        expect(await semibook.estimateVolume({ given: 2, to })).to.deep.equal({
-          estimatedVolume: Big(2),
+        expect(
+          await semibook.estimateVolume({ given: 3, to: "sell" })
+        ).to.deep.equal({
+          estimatedVolume: Big(1.5),
           givenResidue: Big(0),
         });
-      });
-
-      it("returns correct estimate and residue when cache is partial and offer list is insufficient", async function () {
-        // Put one offer on asks
-        await waitForTransaction(
-          newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "1" })
-        );
-        await waitForTransaction(
-          newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "1" })
-        );
-        await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
-
-        // Load 1 offer in cache
-        const market = await mgv.market({
-          base: "TokenA",
-          quote: "TokenB",
-          bookOptions: { maxOffers: 1 },
-        });
-        const semibook = market.getSemibook("asks");
-        expect(await semibook.estimateVolume({ given: 3, to })).to.deep.equal({
-          estimatedVolume: Big(2),
-          givenResidue: Big(1),
-        });
-      });
-    })
-  );
-
-  describe("estimateVolume({to: buy}) - calculation tests", () => {
-    it("returns zero when given is zero", async function () {
-      await waitForTransaction(
-        newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "2" })
-      );
-
-      await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
-      const market = await mgv.market({ base: "TokenA", quote: "TokenB" });
-      const semibook = market.getSemibook("asks");
-      expect(
-        await semibook.estimateVolume({ given: 0, to: "buy" })
-      ).to.deep.equal({
-        estimatedVolume: Big(0),
-        givenResidue: Big(0),
-      });
-    });
-
-    it("estimates all available volume when offer list has 1 offer with insufficient volume", async function () {
-      await waitForTransaction(
-        newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "2" })
-      );
-      await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
-
-      const market = await mgv.market({ base: "TokenA", quote: "TokenB" });
-      const semibook = market.getSemibook("asks");
-      expect(
-        await semibook.estimateVolume({ given: 2, to: "buy" })
-      ).to.deep.equal({
-        estimatedVolume: Big(2),
-        givenResidue: Big(1),
-      });
-    });
-
-    it("estimates all available volume when offer list has multiple offers with insufficient volume", async function () {
-      await waitForTransaction(
-        newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "2" })
-      );
-      await waitForTransaction(
-        newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "3" })
-      );
-      await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
-
-      const market = await mgv.market({ base: "TokenA", quote: "TokenB" });
-      const semibook = market.getSemibook("asks");
-      expect(
-        await semibook.estimateVolume({ given: 3, to: "buy" })
-      ).to.deep.equal({
-        estimatedVolume: Big(5),
-        givenResidue: Big(1),
-      });
-    });
-
-    it("estimates volume and no residue when offer list has 1 offer with sufficient volume", async function () {
-      await waitForTransaction(
-        newOffer(mgv, "TokenA", "TokenB", { gives: "2", wants: "4" })
-      );
-      await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
-
-      const market = await mgv.market({ base: "TokenA", quote: "TokenB" });
-      const semibook = market.getSemibook("asks");
-      expect(
-        await semibook.estimateVolume({ given: 1, to: "buy" })
-      ).to.deep.equal({
-        estimatedVolume: Big(2),
-        givenResidue: Big(0),
-      });
-    });
-
-    it("estimates volume and no residue when offer list has multiple offers which together have sufficient volume", async function () {
-      await waitForTransaction(
-        newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "2" })
-      );
-      await waitForTransaction(
-        newOffer(mgv, "TokenA", "TokenB", { gives: "2", wants: "4" })
-      );
-      await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
-
-      const market = await mgv.market({ base: "TokenA", quote: "TokenB" });
-      const semibook = market.getSemibook("asks");
-      expect(
-        await semibook.estimateVolume({ given: 2, to: "buy" })
-      ).to.deep.equal({
-        estimatedVolume: Big(4),
-        givenResidue: Big(0),
-      });
-    });
-  });
-
-  describe("estimateVolume({to: sell}) - calculation tests", () => {
-    it("returns zero when given is zero", async function () {
-      await waitForTransaction(
-        newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "2" })
-      );
-
-      await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
-      const market = await mgv.market({ base: "TokenA", quote: "TokenB" });
-      const semibook = market.getSemibook("asks");
-      expect(
-        await semibook.estimateVolume({ given: 0, to: "sell" })
-      ).to.deep.equal({
-        estimatedVolume: Big(0),
-        givenResidue: Big(0),
-      });
-    });
-
-    it("estimates all available volume when offer list has 1 offer with insufficient volume", async function () {
-      await waitForTransaction(
-        newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "2" })
-      );
-      await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
-
-      const market = await mgv.market({ base: "TokenA", quote: "TokenB" });
-      const semibook = market.getSemibook("asks");
-      expect(
-        await semibook.estimateVolume({ given: 3, to: "sell" })
-      ).to.deep.equal({
-        estimatedVolume: Big(1),
-        givenResidue: Big(1),
-      });
-    });
-
-    it("estimates all available volume when offer list has multiple offers with insufficient volume", async function () {
-      await waitForTransaction(
-        newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "2" })
-      );
-      await waitForTransaction(
-        newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "3" })
-      );
-      await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
-
-      const market = await mgv.market({ base: "TokenA", quote: "TokenB" });
-      const semibook = market.getSemibook("asks");
-      expect(
-        await semibook.estimateVolume({ given: 6, to: "sell" })
-      ).to.deep.equal({
-        estimatedVolume: Big(2),
-        givenResidue: Big(1),
-      });
-    });
-
-    it("estimates volume and no residue when offer list has 1 offer with sufficient volume", async function () {
-      await waitForTransaction(
-        newOffer(mgv, "TokenA", "TokenB", { gives: "2", wants: "4" })
-      );
-      await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
-
-      const market = await mgv.market({ base: "TokenA", quote: "TokenB" });
-      const semibook = market.getSemibook("asks");
-      expect(
-        await semibook.estimateVolume({ given: 2, to: "sell" })
-      ).to.deep.equal({
-        estimatedVolume: Big(1),
-        givenResidue: Big(0),
-      });
-    });
-
-    it("estimates volume and no residue when offer list has multiple offers which together have sufficient volume", async function () {
-      await waitForTransaction(
-        newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "2" })
-      );
-      await waitForTransaction(
-        newOffer(mgv, "TokenA", "TokenB", { gives: "2", wants: "4" })
-      );
-      await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
-
-      const market = await mgv.market({ base: "TokenA", quote: "TokenB" });
-      const semibook = market.getSemibook("asks");
-      expect(
-        await semibook.estimateVolume({ given: 3, to: "sell" })
-      ).to.deep.equal({
-        estimatedVolume: Big(1.5),
-        givenResidue: Big(0),
       });
     });
   });

--- a/packages/mangrove.js/test/integration/semibook.integration.test.ts
+++ b/packages/mangrove.js/test/integration/semibook.integration.test.ts
@@ -396,4 +396,90 @@ describe("Semibook integration tests suite", () => {
       });
     });
   });
+
+  describe("initialization options", () => {
+    describe("Option.desiredPrice", () => {
+      it("does not fail if offer list is empty", async function () {
+        const market = await mgv.market({
+          base: "TokenA",
+          quote: "TokenB",
+          bookOptions: {
+            desiredPrice: 1,
+            chunkSize: 1, // Fetch only 1 offer in each chunk
+          },
+        });
+        const semibook = market.getSemibook("asks");
+        expect(semibook.size()).to.equal(0);
+      });
+
+      it("fetches all offers if all have a better price", async function () {
+        await waitForTransaction(
+          newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "1" })
+        );
+        await waitForTransaction(
+          newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "2" })
+        );
+        await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
+
+        const market = await mgv.market({
+          base: "TokenA",
+          quote: "TokenB",
+          bookOptions: {
+            desiredPrice: 3,
+            chunkSize: 1, // Fetch only 1 offer in each chunk
+          },
+        });
+        const semibook = market.getSemibook("asks");
+        expect(semibook.size()).to.equal(2);
+      });
+
+      it("fetches only one chunk if no offers have a better price", async function () {
+        await waitForTransaction(
+          newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "2" })
+        );
+        await waitForTransaction(
+          newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "3" })
+        );
+        await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
+
+        const market = await mgv.market({
+          base: "TokenA",
+          quote: "TokenB",
+          bookOptions: {
+            desiredPrice: 1,
+            chunkSize: 1, // Fetch only 1 offer in each chunk
+          },
+        });
+        const semibook = market.getSemibook("asks");
+        expect(semibook.size()).to.equal(1);
+      });
+
+      it("stops fetching when a chunk with a worse price has been fetched", async function () {
+        await waitForTransaction(
+          newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "1" })
+        );
+        await waitForTransaction(
+          newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "2" })
+        );
+        await waitForTransaction(
+          newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "3" })
+        );
+        await waitForTransaction(
+          newOffer(mgv, "TokenA", "TokenB", { gives: "1", wants: "4" })
+        );
+        await mgvTestUtil.eventsForLastTxHaveBeenGenerated;
+
+        const market = await mgv.market({
+          base: "TokenA",
+          quote: "TokenB",
+          bookOptions: {
+            desiredPrice: 2,
+            chunkSize: 1, // Fetch only 1 offer in each chunk
+          },
+        });
+        const semibook = market.getSemibook("asks");
+        expect(semibook.size()).to.equal(3);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Adds new `Market` options as specified in #121:
- `desiredPrice`: allows one to specify a price point of interest. This will cause the cache to initially load all offers with this price or better.
- `desiredVolume`: allows one to specify a volume of interest. This will cause the cache to initially load at least this volume (if available). The option uses the same specification as for `estimateVolume`: `desiredVolume: { given: 1, what: "base", to: "buy" }` will cause the asks semibook to be initialized with a volume of at least 1 base token.

Closes #121.