### PR TITLE
mangrove-solidity: Improve clean-this-package

### DIFF
--- a/packages/mangrove-solidity/package.json
+++ b/packages/mangrove-solidity/package.json
@@ -9,7 +9,7 @@
     "build-this-package": "hardhat compile && yarn run copy-distribution-assets",
     "build": "yarn install && yarn workspaces foreach -vpiR --topological-dev --from $npm_package_name run build-this-package",
     "copy-distribution-assets": "node copyDistributionAssets.js",
-    "clean-this-package": "rimraf build cache dist exported-abis",
+    "clean-this-package": "rimraf deployments/hardhat deployments/localhost artifacts cache dist exported-abis",
     "clean": "yarn workspaces foreach -vpiR --topological-dev --from $npm_package_name run clean-this-package",
     "doc": "solcco -f doc/MgvDoc.html preprocessing/structs.js contracts/MgvLib.sol contracts/MgvRoot.sol contracts/MgvHasOffers.sol contracts/MgvOfferMaking.sol contracts/MgvOfferTaking.sol contracts/MgvOfferTakingWithPermit.sol contracts/MgvGovernable.sol contracts/AbstractMangrove.sol contracts/Mangrove.sol contracts/InvertedMangrove.sol",
     "preproc": "solpp --defs preprocessing/structs.js preprocessing/MgvPack.pre.sol > contracts/MgvPack.sol",


### PR DESCRIPTION
Script `clean-this-package` should also remove old local deployments as well as hardhat artifacts.