### PR TITLE
feat(market): Add `partialFill` flag to `OrderResult`

### DIFF
--- a/packages/mangrove.js/CHANGELOG.md
+++ b/packages/mangrove.js/CHANGELOG.md
@@ -5,6 +5,7 @@
   - `desiredVolume`: allows one to specify a volume of interest. This will cause the cache to initially load at least this volume (if available). The option uses the same specification as for `estimateVolume`: `desiredVolume: { given: 1, what: "base", to: "buy" }` will cause the asks semibook to be initialized with a volume of at least 1 base token.
 - New `Market` subscription: `market.afterBlock(n,callback)` will trigger `callback` after the market events for block `n` have been processed. If the block has already been processed, `callback` will be triggered at the next event loop.
 - Improve logging: add file logging, allow applications using the package to configure logging using local `config` file.
+- New `partialFill` flag in `OrderResult`: This flag will be true if the order was only partially filled.
 
 # 0.1.0 (January 2022)
 

--- a/packages/mangrove.js/src/market.ts
+++ b/packages/mangrove.js/src/market.ts
@@ -32,7 +32,12 @@ import * as TCM from "./types/typechain/Mangrove";
 // eslint-disable-next-line @typescript-eslint/no-namespace
 namespace Market {
   export type MgvReader = typechain.MgvReader;
-  export type OrderResult = { got: Big; gave: Big; penalty: Big };
+  export type OrderResult = {
+    got: Big;
+    gave: Big;
+    partialFill: boolean;
+    penalty: Big;
+  };
   export type BookSubscriptionEvent =
     | ({ name: "OfferWrite" } & TCM.OfferWriteEvent)
     | ({ name: "OfferFail" } & TCM.OfferFailEvent)
@@ -574,9 +579,12 @@ class Market {
     }
     const got_bq = orderType === "buy" ? "base" : "quote";
     const gave_bq = orderType === "buy" ? "quote" : "base";
+    const takerGot: BigNumber = result.args.takerGot;
+    const takerGave: BigNumber = result.args.takerGave;
     return {
-      got: this[got_bq].fromUnits(result.args.takerGot),
-      gave: this[gave_bq].fromUnits(result.args.takerGave),
+      got: this[got_bq].fromUnits(takerGot),
+      gave: this[gave_bq].fromUnits(takerGave),
+      partialFill: fillWants ? takerGot.lt(wants) : takerGave.lt(gives),
       penalty: this.mgv.fromUnits(result.args.penalty, 18),
     };
   }


### PR DESCRIPTION
This flag will be true if the order was only partially filled.