### PR TITLE
fix(mangrove.js/deps): set commonlib.js as a bundledDependency

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -448,7 +448,7 @@ jobs:
 
   # ==== Job: Build and test mangrove.js ====
   mangrove-js:
-    needs: [security-guard, mangrove-solidity, hardhat-utils]
+    needs: [security-guard, commonlib-js, mangrove-solidity, hardhat-utils]
 
     runs-on: ubuntu-latest
 
@@ -498,6 +498,16 @@ jobs:
       uses: montudor/action-zip@v1
       with:
         args: unzip -qq mangrove-solidity-out.zip
+
+    - name: Download cached commonlib.js artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: commonlib-out.zip
+
+    - name: Unzip commonlib.js artifact
+      uses: montudor/action-zip@v1
+      with:
+        args: unzip -qq commonlib-out.zip
 
     # NOTE: Uncomment the following two steps, if/when hardhat-utils has build artefacts -->
     # - name: Download cached hardhat-utils artifact

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -448,7 +448,7 @@ jobs:
 
   # ==== Job: Build and test mangrove.js ====
   mangrove-js:
-    needs: [security-guard, commonlib-js, mangrove-solidity, hardhat-utils]
+    needs: [security-guard, mangrove-solidity, hardhat-utils]
 
     runs-on: ubuntu-latest
 
@@ -498,16 +498,6 @@ jobs:
       uses: montudor/action-zip@v1
       with:
         args: unzip -qq mangrove-solidity-out.zip
-
-    - name: Download cached commonlib.js artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: commonlib-out.zip
-
-    - name: Unzip commonlib.js artifact
-      uses: montudor/action-zip@v1
-      with:
-        args: unzip -qq commonlib-out.zip
 
     # NOTE: Uncomment the following two steps, if/when hardhat-utils has build artefacts -->
     # - name: Download cached hardhat-utils artifact

--- a/packages/mangrove.js/package.json
+++ b/packages/mangrove.js/package.json
@@ -69,6 +69,9 @@
     "object.pick": "^1.3.0",
     "typedoc": "^0.22.3"
   },
+  "bundledDependencies": [
+    "@mangrovedao/commonlib-js"
+  ],
   "devDependencies": {
     "@espendk/json-file-reporter": "^1.4.2",
     "@ethersproject/abi": "^5.0.0",


### PR DESCRIPTION
[Bundled dependencies](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#bundleddependencies) allows to pack an internal and unpublished dependency (commonlib.js) in mangrove.js NPM package.

Fixes #220.