### PR TITLE
Apply Chainsecurity's suggestions following diff audit

### DIFF
--- a/packages/mangrove-solidity/contracts/MgvLib.sol
+++ b/packages/mangrove-solidity/contracts/MgvLib.sol
@@ -48,7 +48,7 @@ library MgvLib {
   struct OrderResult {
     /* `makerdata` holds a message that was either returned by the maker or passed as revert message at the end of the trade execution*/
     bytes32 makerData;
-    /* `mgvData` is an [internal Mangrove status](#MgvOfferTaking/statusCodes) code. */
+    /* `mgvData` is an [internal Mangrove status code](#MgvOfferTaking/statusCodes) code. */
     bytes32 mgvData;
   }
 }
@@ -99,7 +99,7 @@ contract HasMgvEvents {
   event OrderComplete(
     address indexed outbound_tkn,
     address indexed inbound_tkn,
-    address taker,
+    address indexed taker,
     uint takerGot,
     uint takerGave,
     uint penalty
@@ -186,7 +186,11 @@ contract HasMgvEvents {
 
 /* # IMaker interface */
 interface IMaker {
-  /* Called upon offer execution. If the call returns normally with the first 32 bytes are 0, Mangrove will try to transfer funds; otherwise not. Returned data (truncated to leftmost 32 bytes) can be accessed during the call to `makerPosthook` in the `result.mgvData` field. To revert with a 32 bytes value, use something like:
+  /* Called upon offer execution. 
+  - If the call fails, Mangrove will not try to transfer funds.
+  - If the call succeeds but returndata's first 32 bytes are not 0, Mangrove will not try to transfer funds either.
+  - If the call succeeds and returndata's first 32 bytes are 0, Mangrove will try to transfer funds.
+  In other words, you may declare failure by reverting or by returning nonzero data. In both cases, those 32 first bytes will be passed back to you during the call to `makerPosthook` in the `result.mgvData` field.
      ```
      function tradeRevert(bytes32 data) internal pure {
        bytes memory revData = new bytes(32);

--- a/packages/mangrove-solidity/contracts/MgvOfferMaking.sol
+++ b/packages/mangrove-solidity/contracts/MgvOfferMaking.sol
@@ -62,7 +62,7 @@ contract MgvOfferMaking is MgvHasOffers {
 
   An offer cannot be inserted in a closed market, nor when a reentrancy lock for `outbound_tkn`,`inbound_tkn` is on.
 
-  No more than $2^{24}-1$ offers can ever be created for one `outbound_tkn`,`inbound_tkn` pair.
+  No more than $2^{32}-1$ offers can ever be created for one `outbound_tkn`,`inbound_tkn` pair.
 
   The actual contents of the function is in `writeOffer`, which is called by both `newOffer` and `updateOffer`.
   */
@@ -248,7 +248,7 @@ contract MgvOfferMaking is MgvHasOffers {
   function writeOffer(OfferPack memory ofp, bool update) internal { unchecked {
     /* `gasprice`'s floor is Mangrove's own gasprice estimate, `ofp.global.gasprice`. We first check that gasprice fits in 16 bits. Otherwise it could be that `uint16(gasprice) < global_gasprice < gasprice`, and the actual value we store is `uint16(gasprice)`. */
     require(
-      uint16(ofp.gasprice) == ofp.gasprice,
+      checkGasprice(ofp.gasprice),
       "mgv/writeOffer/gasprice/16bits"
     );
 

--- a/packages/mangrove-solidity/contracts/MgvOfferTaking.sol
+++ b/packages/mangrove-solidity/contracts/MgvOfferTaking.sol
@@ -336,8 +336,8 @@ abstract contract MgvOfferTaking is MgvHasOffers {
     //+clear+
 
     emit OrderComplete(
-      outbound_tkn,
-      inbound_tkn,
+      sor.outbound_tkn,
+      sor.inbound_tkn,
       taker,
       snipesGot,
       snipesGave,
@@ -349,7 +349,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
 
   /* ## Internal snipes */
   //+clear+
-  /* `internalSnipes` works by looping over targets. Each successive offer is executed under a [reentrancy lock](#internalSnipes/liftReentrancy), then its posthook is called.y lock [is lifted](). Going upward, each offer's `maker` contract is called again with its remaining gas and given the chance to update its offers on the book. */
+  /* `internalSnipes` works by looping over targets. Each successive offer is executed under a [reentrancy lock](#internalSnipes/liftReentrancy), then its posthook is called. Going upward, each offer's `maker` contract is called again with its remaining gas and given the chance to update its offers on the book. */
   function internalSnipes(
     MultiOrder memory mor,
     ML.SingleOrder memory sor,


### PR DESCRIPTION
* Clarified IMaker interface description
* Updated comments on `offerId` size (24->32bits)
* Indexed `taker` field in `OrderComplete`
* Use `checkGasprice` in `writeOffer`

+ replace `{out,in}bound_tkn` with `sor.{out,in}bound` to avoid new
Stack Too Deep error.