### PR TITLE
fix(logging): Remove dependency on commonlib.js as temp workaround for #220

### DIFF
--- a/packages/mangrove.js/CHANGELOG.md
+++ b/packages/mangrove.js/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Next version
 
+# 0.3.1 (March 2022)
+
+- The new logging has been stunted: It only logs to the console and without timestamps
+  - This is a temporary workaround to issue #220
+
 # 0.2.0 (February 2022)
 
 - New `Market` options:

--- a/packages/mangrove.js/package.json
+++ b/packages/mangrove.js/package.json
@@ -59,7 +59,6 @@
   },
   "dependencies": {
     "@ethersproject/experimental": "^5.5.0",
-    "@mangrovedao/commonlib-js": "workspace:*",
     "async-mutex": "^0.3.2",
     "big.js": "^6.1.1",
     "config": "^3.3.6",

--- a/packages/mangrove.js/src/util/logger.ts
+++ b/packages/mangrove.js/src/util/logger.ts
@@ -1,30 +1,38 @@
-import {
-  createLogger,
-  BetterLogger,
-  format,
-  transports,
-  logdataLimiter,
-} from "@mangrovedao/commonlib-js";
-import os from "os";
+// FIXME: The logger has been stunted by removing the dependency to commonlib.js
+//        as a temporary workaround for issue #220.
+//        To avoid reverting a merge commit and the burden of maintaining that old feature branch,
+//        we have opted to keep most of the logging code but only support simplified logging to console.
+//
+//        For references on why we want to avoid revert merge commits:
+//          Long (Linus): https://github.com/git/git/blob/master/Documentation/howto/revert-a-faulty-merge.txt
+//          Short: https://www.datree.io/resources/git-undo-merge
+// import {
+//   createLogger,
+//   BetterLogger,
+//   format,
+//   transports,
+//   logdataLimiter,
+// } from "@mangrovedao/commonlib-js";
+// import os from "os";
 import safeStringify from "fast-safe-stringify";
 import config from "./config";
 
-const consoleLogFormat = format.printf(
-  ({ level, message, timestamp, ...metadata }) => {
-    let msg = `${timestamp} [${level}] `;
-    if (metadata.contextInfo) {
-      msg += `[${metadata.contextInfo}] `;
-    }
-    msg += message;
-    if (metadata.data !== undefined) {
-      msg += ` | data: ${stringifyData(metadata.data)}`;
-    }
-    if (metadata.stack) {
-      msg += `${os.EOL}${metadata.stack}`;
-    }
-    return msg;
-  }
-);
+// const consoleLogFormat = format.printf(
+//   ({ level, message, timestamp, ...metadata }) => {
+//     let msg = `${timestamp} [${level}] `;
+//     if (metadata.contextInfo) {
+//       msg += `[${metadata.contextInfo}] `;
+//     }
+//     msg += message;
+//     if (metadata.data !== undefined) {
+//       msg += ` | data: ${stringifyData(metadata.data)}`;
+//     }
+//     if (metadata.stack) {
+//       msg += `${os.EOL}${metadata.stack}`;
+//     }
+//     return msg;
+//   }
+// );
 
 const stringifyData = (data) => {
   if (typeof data == "string") return data;
@@ -39,27 +47,43 @@ const logLevel = config.MangroveJs.has("logLevel")
 
 const additionalTransports = [];
 
-if (config.MangroveJs.has("logFile")) {
-  const logFile = config.MangroveJs.get<string>("logFile");
-  additionalTransports.push(
-    new transports.File({
-      level: logLevel,
-      filename: logFile,
-      format: format.combine(
-        format.splat(),
-        format.timestamp(),
-        consoleLogFormat
-      ),
-    })
-  );
-}
+// if (config.MangroveJs.has("logFile")) {
+//   const logFile = config.MangroveJs.get<string>("logFile");
+//   additionalTransports.push(
+//     new transports.File({
+//       level: logLevel,
+//       filename: logFile,
+//       format: format.combine(
+//         format.splat(),
+//         format.timestamp(),
+//         consoleLogFormat
+//       ),
+//     })
+//   );
+// }
 
-export { logdataLimiter };
+// FIXME: Temporary copy until issue #220 is fixed
+export const logdataLimiter = (data: Object): string => {
+  return safeStringify(data, undefined, undefined, {
+    depthLimit: 3,
+    edgesLimit: Number.MAX_SAFE_INTEGER,
+  });
+};
+// export { logdataLimiter };
 
-export const logger: BetterLogger = createLogger(
-  consoleLogFormat,
-  logLevel,
-  additionalTransports
-);
+// FIXME: Temporary dumb implementation until issue #220 is fixed
+export const logger = {
+  debug: (msg, data) => {
+    console.log(msg + " " + stringifyData(data));
+  },
+  warn: (msg, data) => {
+    console.warn(msg + " " + stringifyData(data));
+  },
+};
+// export const logger: BetterLogger = createLogger(
+//   consoleLogFormat,
+//   logLevel,
+//   additionalTransports
+// );
 
 export default logger;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1190,7 +1190,6 @@ __metadata:
     "@ethersproject/experimental": ^5.5.0
     "@ethersproject/hardware-wallets": ^5.0.0
     "@ethersproject/providers": ^5.0.0
-    "@mangrovedao/commonlib-js": "workspace:*"
     "@mangrovedao/hardhat-utils": "workspace:*"
     "@mangrovedao/mangrove-solidity": "workspace:*"
     "@nomiclabs/hardhat-ethers": ^2.0.2


### PR DESCRIPTION
The logger has been stunted by removing the dependency to commonlib.js
as a temporary workaround for issue #220.

To avoid reverting a merge commit and the burden of maintaining that old feature branch,
we have opted to keep most of the logging code but only support simplified logging to console.

For references on why we want to avoid revert merge commits:

Long (Linus): https://github.com/git/git/blob/master/Documentation/howto/revert-a-faulty-merge.txt
Short: https://www.datree.io/resources/git-undo-merge