### PR TITLE
Feature/ci/check and update deploy addr

### DIFF
--- a/.github/scripts/package-lock.json
+++ b/.github/scripts/package-lock.json
@@ -1,0 +1,41 @@
+{
+  "name": "scripts",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "marked": "^4.0.12",
+        "minimist": "^1.2.6"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+    }
+  },
+  "dependencies": {
+    "marked": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ=="
+    },
+    "minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+    }
+  }
+}

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "marked": "^4.0.12",
+    "minimist": "^1.2.6"
+  }
+}

--- a/.github/scripts/write-addresses-json.js
+++ b/.github/scripts/write-addresses-json.js
@@ -1,0 +1,116 @@
+/*
+Script to a write addresses for a chain to a json file (at a given path), given a deployment-folder
+with hardhat deployment json files with addresses for Mangrove contracts.
+
+Writes a new file, if output file is not already present. If output file is found, only updates the
+values for the chain and contracts corresponding to the given argument for chainkey and the known
+names of Mangrove contracts, and leaves other key-value pairs.
+
+Args:
+  --deployment=<path to deployments folder for addresses>
+  --chainkey=<key for chain in output json file>
+  --output=<path to output json file>
+  [--debug]
+
+  Add --debug flag to get debug output.
+
+Example:
+
+  node write-addresses-json.js --deployment ../../packages/mangrove-solidity/deployments/mumbai --chainkey maticmum --output ../../packages/mangrove.js/src/constants/addresses.json 
+*/
+
+const path = require('path');
+const fs = require('fs')
+
+// read args - and do minimal sanity checking
+const stringArgs = ['deployment', 'chainkey', 'output'];
+
+const args = require("minimist")(
+  process.argv.slice(2), {
+    string: stringArgs, 
+    boolean: ["debug"], 
+    unknown: (a) => {console.error(`Unexpected argument '${a}'- ignoring.`); return false; }
+  });
+
+let debug = false;
+if(args.debug){
+  debug = true;
+}
+
+if(debug){
+  console.debug("Args:")
+  console.debug(args);
+}
+
+let error = false;
+for (let i = 0; i < stringArgs.length; i++) {
+  const name = stringArgs[i];
+
+  if(!(name in args)){
+    console.error(`Error: Missing argument ${name}.`);
+    error = true;
+  }
+}
+
+if(error){
+  process.exit(1);
+}
+
+const deploymentFolder = args['deployment'];
+const chainkey = args['chainkey'];
+const outputFile = args['output'];
+
+// define relevant contracts
+const contractAddressesToOutput = [ "Mangrove", "MgvCleaner", "MgvReader", "MgvOracle" ];
+
+// read deployment addresses for relevant contracts
+function getAddr(contract, jsonPath) {
+  try {
+    const filePath = path.join(deploymentFolder, contract + ".json"); 
+    const deployJson = require(filePath);
+    const address = deployJson[jsonPath];
+    if(debug){
+      console.debug(`Found address '${address}' for contract ${contract} in file ${filePath}.`)
+    }
+    return address;
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+const contractAddresses = contractAddressesToOutput.reduce(
+  (prev, contract) => { 
+    return {...prev, [contract]: getAddr(contract, "address") } 
+  }, 
+  {});
+
+// read outputFile, if present
+let oldAddresses = {};
+if (fs.existsSync(outputFile)) {
+  if(debug){
+    console.debug(`Found existing file at ${outputFile}. File will be updated.`);
+  }
+
+  oldAddresses = require(outputFile);
+}
+else {
+  if(debug){
+    console.debug(`Did not find file at ${outputFile}. File will be created.`);
+  }
+}
+
+// Overwrite info for relevant addresses for the relevant chainkey, and then write to file.
+// (Note - we don't test whether there are actually any changes, and we always write to file, so
+// the file timestamp will always be updated. This script is intended for CI, so it's an
+// unnecessary hassle to actually test for changes.) 
+
+const newChainAddresses = Object.assign(oldAddresses[chainkey] ?? {}, contractAddresses);
+const newAddresses = Object.assign(oldAddresses, {[chainkey] : newChainAddresses});
+
+if(debug){
+  console.debug(`Constructed the following content, which will be written to file at ${outputFile}.}`)
+  console.dir(newAddresses);
+}
+
+fs.writeFileSync(outputFile, JSON.stringify(newAddresses, null, 2));

--- a/.github/workflows/updateadr.yml
+++ b/.github/workflows/updateadr.yml
@@ -23,9 +23,11 @@ jobs:
           node-version: '14'
 
       - run: npm ci
+        working-directory: ./.github/scripts
 
       - name: Check and update deployment addresses in mangrove.js
-        run: node ./.github/scripts/write-addresses-json.js --deployment $GITHUB_WORKSPACE/packages/mangrove-solidity/deployments/mumbai --chainkey maticmum --output $GITHUB_WORKSPACE/packages/mangrove.js/src/constants/addresses.json --debug
+        run: node write-addresses-json.js --deployment $GITHUB_WORKSPACE/packages/mangrove-solidity/deployments/mumbai --chainkey maticmum --output $GITHUB_WORKSPACE/packages/mangrove.js/src/constants/addresses.json --debug
+        working-directory: ./.github/scripts
 
       - name: Create commit and PR, if there are changes
         uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/updateadr.yml
+++ b/.github/workflows/updateadr.yml
@@ -1,0 +1,46 @@
+name: Check and update deployment addresses in mangrove.js
+
+# run on master to detect and create PR's to fix any discrepancy between deployment addresses for
+# core contracts in mangrove-solidity and mangrove.js
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["CI"]
+    branches: [master]
+    types:
+      - completed
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - run: npm ci
+
+      - name: Check and update deployment addresses in mangrove.js
+        run: node ./.github/scripts/write-addresses-json.js --deployment $GITHUB_WORKSPACE/packages/mangrove-solidity/deployments/mumbai --chainkey maticmum --output $GITHUB_WORKSPACE/packages/mangrove.js/src/constants/addresses.json --debug
+
+      - name: Create commit and PR, if there are changes
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: 'Update deployment addresses in mangrove.js'
+          title: 'Update deployment addresses in mangrove.js'
+          add-paths: 'packages/mangrove.js/src/constants/addresses.json'
+          delete-branch: true
+          assignees: 'dontrolle'
+
+      # Use this step instead, to simply commit and push changes directly to master
+      # - name: Commit and push any changes to deployment addresses
+      #   uses: EndBug/add-and-commit@v9
+      #   with:
+      #     default_author: github_actions
+      #     message: 'Update deployment addresses in mangrove.js'
+      #     push: true 
+      #     add: 'packages/mangrove.js/src/constants/addresses.json'


### PR DESCRIPTION
Add GitHub workflow with script to test and update deployment addresses in `mangrove.js`, if relevant deployment addresses in `mangrove-solidity` changed. Currently runs only for mumbai testchain.