### PR TITLE
feat!: Exit the bot on unhandled rejections

### DIFF
--- a/packages/bot-maker-noise/src/index.ts
+++ b/packages/bot-maker-noise/src/index.ts
@@ -281,7 +281,9 @@ async function logTokenBalance(
 }
 
 process.on("unhandledRejection", function (reason, promise) {
-  logger.warn("Unhandled Rejection", { data: reason });
+  logger.error("Unhandled Rejection", { data: reason });
+  // The bot seems to hang on unhandled rejections, so exit and allow the app platform to restart the bot
+  process.exit(1); // TODO Add exit codes
 });
 
 main().catch((e) => {


### PR DESCRIPTION
The bot seems to hang after undhandled rejections so we now quit and allow Heroku to restart it.