### PR TITLE
fix(ci): Assign dependabot reviewer dontrolle

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,13 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    reviewers:
+      - "dontrolle"      
 
   # Maintain dependencies for npm and yarn
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
+    reviewers:
+      - "dontrolle"      


### PR DESCRIPTION
For now, @dontrolle handles dependabot as we are testing it out.