### PR TITLE
feat(Greedy Taker bot): Use Toad Scheduler instead of `sleep` and rely on nodejs shutdown

### DIFF
--- a/packages/bot-taker-greedy/package.json
+++ b/packages/bot-taker-greedy/package.json
@@ -43,7 +43,8 @@
     "fast-safe-stringify": "^2.1.1",
     "finalhandler": "^1.1.2",
     "random": "^3.0.6",
-    "serve-static": "^1.15.0"
+    "serve-static": "^1.15.0",
+    "toad-scheduler": "^1.6.0"
   },
   "devDependencies": {
     "@espendk/json-file-reporter": "^1.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1394,6 +1394,7 @@ __metadata:
     rimraf: ^3.0.2
     serve-static: ^1.15.0
     shelljs: ^0.8.4
+    toad-scheduler: ^1.6.0
     ts-node: ^10.2.1
     typescript: ^4.4.2
   languageName: unknown


### PR DESCRIPTION
According to the Nodejs documentation, calling `process.exit()` is bad practice: https://nodejs.org/api/process.html#processexitcode
One risk is that any logs written before exiting may not be written.

The process shutdown logic has therefore been changed to stop all takers and thereby remove all work from the event loop which should cause Nodejs to shut down.

As part of this, the `OfferTaker` class has been changed to use ToadScheduler instead of an infinite loop with a `sleep` call; This is easier to stop immediately and more flexible (and we use it in other bots).