### PR TITLE
feat(Gas Updater): Graceful shutdown

### DIFF
--- a/packages/bot-updategas/src/index.ts
+++ b/packages/bot-updategas/src/index.ts
@@ -210,9 +210,14 @@ const server = http.createServer(function (req, res) {
 
 server.listen(process.env.PORT || 8080);
 
+// Stop gracefully and rely on NodeJS shutting down when no more work is scheduled.
+// This allows any logging to be processed before exiting (which isn't guaranteed
+// if `process.exit` is called).
 function stopAndExit(exitStatusCode: number) {
+  logger.info("Stopping and exiting", { data: { exitCode: exitStatusCode } });
+  process.exitCode = exitStatusCode;
   scheduler.stop();
-  server.close(() => process.exit(exitStatusCode));
+  server.close();
 }
 
 // Exiting on unhandled rejections and exceptions allows the app platform to restart the bot


### PR DESCRIPTION
Let NodeJS handle shutdown when there's no more work instead of calling `process.exit`.
This allows any logging to complete before closing down.