### PR TITLE
chore: Add minimist as an explicit dev-dependency

### DIFF
--- a/packages/mangrove.js/package.json
+++ b/packages/mangrove.js/package.json
@@ -101,6 +101,7 @@
     "hardhat-deploy": "^0.9.1",
     "hardhat-deploy-ethers": "^0.3.0-beta.10",
     "lint-staged": "^10.5.1",
+    "minimist": "^1.2.6",
     "mocha": "^9.2.2",
     "mocha-multi-reporters": "^1.5.1",
     "npm-run-all": "^4.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1735,6 +1735,7 @@ __metadata:
     hardhat-deploy: ^0.9.1
     hardhat-deploy-ethers: ^0.3.0-beta.10
     lint-staged: ^10.5.1
+    minimist: ^1.2.6
     mocha: ^9.2.2
     mocha-multi-reporters: ^1.5.1
     npm-run-all: ^4.1.5
@@ -7293,6 +7294,13 @@ fsevents@~2.3.2:
   version: 1.2.5
   resolution: "minimist@npm:1.2.5"
   checksum: 86706ce5b36c16bfc35c5fe3dbb01d5acdc9a22f2b6cc810b6680656a1d2c0e44a0159c9a3ba51fb072bb5c203e49e10b51dcd0eec39c481f4c42086719bae52
+  languageName: node
+  linkType: hard
+
+"minimist@npm:^1.2.6":
+  version: 1.2.6
+  resolution: "minimist@npm:1.2.6"
+  checksum: d15428cd1e11eb14e1233bcfb88ae07ed7a147de251441d61158619dfb32c4d7e9061d09cab4825fdee18ecd6fce323228c8c47b5ba7cd20af378ca4048fb3fb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Is required by a few test-scripts. Allows us to control version explicitly.