### PR TITLE
feat: Use `ethers.getDefaultProvider` instead of limited protocol-specific providers

### DIFF
--- a/packages/bot-cleaning/src/index.ts
+++ b/packages/bot-cleaning/src/index.ts
@@ -8,7 +8,7 @@ import config from "./util/config";
 import { logger } from "./util/logger";
 
 import Mangrove from "@mangrovedao/mangrove.js";
-import { WebSocketProvider } from "@ethersproject/providers";
+import { getDefaultProvider } from "@ethersproject/providers";
 import { NonceManager } from "@ethersproject/experimental";
 import { Wallet } from "@ethersproject/wallet";
 
@@ -47,7 +47,7 @@ const main = async () => {
   if (!process.env["PRIVATE_KEY"]) {
     throw new Error("No private key provided in PRIVATE_KEY");
   }
-  const provider = new WebSocketProvider(process.env["ETHEREUM_NODE_URL"]);
+  const provider = getDefaultProvider(process.env["ETHEREUM_NODE_URL"]);
   const signer = new Wallet(process.env["PRIVATE_KEY"], provider);
   const nonceManager = new NonceManager(signer);
   const mgv = await Mangrove.connect({ signer: nonceManager });

--- a/packages/bot-cleaning/test/integration/marketCleaner.integration.tests.ts
+++ b/packages/bot-cleaning/test/integration/marketCleaner.integration.tests.ts
@@ -29,7 +29,7 @@ let market: Market;
 
 describe("MarketCleaner integration tests", () => {
   before(async function () {
-    testProvider = new ethers.providers.JsonRpcProvider(
+    testProvider = ethers.getDefaultProvider(
       this.test?.parent?.parent?.ctx.providerUrl
     );
   });

--- a/packages/bot-maker-noise/src/index.ts
+++ b/packages/bot-maker-noise/src/index.ts
@@ -10,7 +10,7 @@ import { logger } from "./util/logger";
 import Mangrove, { MgvToken } from "@mangrovedao/mangrove.js";
 
 import { ethers } from "ethers";
-import { WebSocketProvider, Provider } from "@ethersproject/providers";
+import { getDefaultProvider, Provider } from "@ethersproject/providers";
 import { NonceManager } from "@ethersproject/experimental";
 import { Wallet } from "@ethersproject/wallet";
 
@@ -42,7 +42,7 @@ const main = async () => {
   if (!process.env["PRIVATE_KEY"]) {
     throw new Error("No private key provided in PRIVATE_KEY");
   }
-  const provider = new WebSocketProvider(process.env["ETHEREUM_NODE_URL"]);
+  const provider = getDefaultProvider(process.env["ETHEREUM_NODE_URL"]);
   const signer = new Wallet(process.env["PRIVATE_KEY"], provider);
   // We will probably be waiting for multiple tx's at the same time
   // (e.g. for different markets), so we must keep track of nonces.

--- a/packages/bot-template/src/index.ts
+++ b/packages/bot-template/src/index.ts
@@ -9,7 +9,7 @@ import { logger } from "./util/logger";
 import { TemplateBot } from "./TemplateBot";
 
 import Mangrove from "@mangrovedao/mangrove.js";
-import { WebSocketProvider } from "@ethersproject/providers";
+import { getDefaultProvider } from "@ethersproject/providers";
 import { NonceManager } from "@ethersproject/experimental";
 import { Wallet } from "@ethersproject/wallet";
 
@@ -34,7 +34,7 @@ const main = async () => {
   if (!process.env["PRIVATE_KEY"]) {
     throw new Error("No private key provided in PRIVATE_KEY");
   }
-  const provider = new WebSocketProvider(process.env["ETHEREUM_NODE_URL"]);
+  const provider = getDefaultProvider(process.env["ETHEREUM_NODE_URL"]);
   const signer = new Wallet(process.env["PRIVATE_KEY"], provider);
   const nonceManager = new NonceManager(signer);
   const mgv = await Mangrove.connect({ signer: nonceManager });

--- a/packages/bot-updategas/src/index.ts
+++ b/packages/bot-updategas/src/index.ts
@@ -8,7 +8,7 @@ import { logger } from "./util/logger";
 import { GasUpdater, OracleSourceConfiguration } from "./GasUpdater";
 
 import Mangrove from "@mangrovedao/mangrove.js";
-import { WebSocketProvider } from "@ethersproject/providers";
+import { getDefaultProvider } from "@ethersproject/providers";
 import { NonceManager } from "@ethersproject/experimental";
 import { Wallet } from "@ethersproject/wallet";
 
@@ -45,7 +45,7 @@ const main = async () => {
   if (!process.env["PRIVATE_KEY"]) {
     throw new Error("No private key provided in PRIVATE_KEY");
   }
-  const provider = new WebSocketProvider(process.env["ETHEREUM_NODE_URL"]);
+  const provider = getDefaultProvider(process.env["ETHEREUM_NODE_URL"]);
   const signer = new Wallet(process.env["PRIVATE_KEY"], provider);
   const nonceManager = new NonceManager(signer);
   const mgv = await Mangrove.connect({ signer: nonceManager });

--- a/packages/hardhat-utils/mocha/hooks/integration-test-root-hooks.js
+++ b/packages/hardhat-utils/mocha/hooks/integration-test-root-hooks.js
@@ -6,7 +6,8 @@
 // Set up hardhat
 const hre = require("hardhat");
 const hardhatUtils = require("../../hardhat-utils");
-const JsonRpcProvider = require("@ethersproject/providers").JsonRpcProvider;
+const getDefaultProvider =
+  require("@ethersproject/providers").getDefaultProvider;
 
 const ethers = hre.ethers;
 

--- a/packages/mangrove-solidity/scripts/demo.js
+++ b/packages/mangrove-solidity/scripts/demo.js
@@ -4,9 +4,7 @@ util.inspect.replDefaults.depth = 0;
 const env = require("dotenv").config();
 const { Mangrove } = require("../mangrove/packages/mangrove.js");
 const ethers = require("ethers");
-let provider = new ethers.providers.WebSocketProvider(
-  env.parsed.MUMBAI_NODE_URL
-);
+let provider = ethers.getDefaultProvider(env.parsed.MUMBAI_NODE_URL);
 
 let wallet = new ethers.Wallet(env.parsed.MUMBAI_TESTER_PRIVATE_KEY, provider);
 

--- a/packages/mangrove-solidity/scripts/governance/MGVActivateMarkets.js
+++ b/packages/mangrove-solidity/scripts/governance/MGVActivateMarkets.js
@@ -3,7 +3,7 @@ const chalk = require("chalk");
 const { Mangrove } = require("../../../mangrove.js");
 
 async function main() {
-  const provider = new ethers.providers.JsonRpcProvider(hre.network.config.url);
+  const provider = ethers.getDefaultProvider(hre.network.config.url);
   if (!process.env["MUMBAI_DEPLOYER_PRIVATE_KEY"]) {
     console.error("No tester account defined");
   }

--- a/packages/mangrove-solidity/scripts/helper.js
+++ b/packages/mangrove-solidity/scripts/helper.js
@@ -3,7 +3,7 @@ const { ethers } = require("../../mangrove.js/node_modules/ethers/lib");
 
 function getProvider() {
   const url = hre.network.config.url;
-  return new hre.ethers.providers.JsonRpcProvider(url);
+  return new hre.ethers.getDefaultProvider(url);
 }
 
 function tryGet(cfg, name) {
@@ -53,10 +53,7 @@ function getAave() {
     `aave.addressesProviderAbi`
   ));
   const priceOracleAddr = tryGet(env, `aave.priceOracleAddress`);
-  const priceOracleAbi = require(tryGet(
-    env,
-    `aave.priceOracleAbi`
-  ));
+  const priceOracleAbi = require(tryGet(env, `aave.priceOracleAbi`));
 
   const provider = getProvider();
   const aave = {};

--- a/packages/mangrove-solidity/scripts/mumbai/prodTests/Credit/creditTester.js
+++ b/packages/mangrove-solidity/scripts/mumbai/prodTests/Credit/creditTester.js
@@ -2,7 +2,7 @@ const { ethers } = require("hardhat");
 const { Mangrove } = require("../../../../../mangrove.js");
 
 async function main() {
-  const provider = new ethers.providers.WebSocketProvider(network.config.url);
+  const provider = ethers.getDefaultProvider(network.config.url);
 
   const tester = new ethers.Wallet(
     process.env["MUMBAI_TESTER_PRIVATE_KEY"],

--- a/packages/mangrove-solidity/scripts/mumbai/prodTests/MM/fundMango.js
+++ b/packages/mangrove-solidity/scripts/mumbai/prodTests/MM/fundMango.js
@@ -2,7 +2,7 @@ const { ethers, network } = require("hardhat");
 const { Mangrove } = require("../../../../../mangrove.js");
 
 async function main() {
-  const provider = new ethers.providers.JsonRpcProvider(network.config.url);
+  const provider = ethers.getDefaultProvider(network.config.url);
 
   const tester = new ethers.Wallet(
     process.env["MUMBAI_TESTER_PRIVATE_KEY"],

--- a/packages/mangrove-solidity/scripts/mumbai/prodTests/MM/initializeMango.js
+++ b/packages/mangrove-solidity/scripts/mumbai/prodTests/MM/initializeMango.js
@@ -2,8 +2,7 @@ const { ethers, network } = require("hardhat");
 const { Mangrove } = require("../../../../../mangrove.js");
 
 async function main() {
-  //const provider = new ethers.providers.WebSocketProvider(network.config.url);
-  const provider = new ethers.providers.JsonRpcProvider(network.config.url);
+  const provider = ethers.getDefaultProvider(network.config.url);
 
   if (!process.env["MUMBAI_DEPLOYER_PRIVATE_KEY"]) {
     console.error("No deployer account defined");

--- a/packages/mangrove-solidity/scripts/mumbai/prodTests/MM/shiftMango.js
+++ b/packages/mangrove-solidity/scripts/mumbai/prodTests/MM/shiftMango.js
@@ -2,7 +2,7 @@ const { ethers, network } = require("hardhat");
 const { Mangrove } = require("../../../../../mangrove.js");
 
 async function main() {
-  const provider = new ethers.providers.JsonRpcProvider(network.config.url);
+  const provider = ethers.getDefaultProvider(network.config.url);
 
   const tester = new ethers.Wallet(
     process.env["MUMBAI_TESTER_PRIVATE_KEY"],

--- a/packages/mangrove-solidity/scripts/mumbai/prodTests/MM/shutdownMango.js
+++ b/packages/mangrove-solidity/scripts/mumbai/prodTests/MM/shutdownMango.js
@@ -2,7 +2,7 @@ const { ethers, network } = require("hardhat");
 const { Mangrove } = require("../../../../../mangrove.js");
 
 async function main() {
-  const provider = new ethers.providers.JsonRpcProvider(network.config.url);
+  const provider = ethers.getDefaultProvider(network.config.url);
 
   if (!process.env["MUMBAI_DEPLOYER_PRIVATE_KEY"]) {
     console.error("No deployer account defined");

--- a/packages/mangrove-solidity/scripts/mumbai/prodTests/OasisLike/OasisLikeActivateMarkets.js
+++ b/packages/mangrove-solidity/scripts/mumbai/prodTests/OasisLike/OasisLikeActivateMarkets.js
@@ -2,7 +2,7 @@ const hre = require("hardhat");
 const { Mangrove } = require("../../../../../mangrove.js");
 
 async function main() {
-  const provider = new ethers.providers.JsonRpcProvider(hre.network.config.url);
+  const provider = ethers.getDefaultProvider(hre.network.config.url);
 
   if (!process.env["MUMBAI_DEPLOYER_PRIVATE_KEY"]) {
     console.error("No tester account defined");

--- a/packages/mangrove-solidity/scripts/mumbai/prodTests/OfferProxy/OfferProxyActivateMarkets.js
+++ b/packages/mangrove-solidity/scripts/mumbai/prodTests/OfferProxy/OfferProxyActivateMarkets.js
@@ -2,7 +2,7 @@ const hre = require("hardhat");
 const { Mangrove } = require("../../../../../mangrove.js");
 
 async function main() {
-  const provider = new ethers.providers.JsonRpcProvider(hre.network.config.url);
+  const provider = ethers.getDefaultProvider(hre.network.config.url);
 
   if (!process.env["MUMBAI_DEPLOYER_PRIVATE_KEY"]) {
     console.error("No tester account defined");

--- a/packages/mangrove-solidity/scripts/mumbai/prodTests/OfferProxy/PostOfferViaProxy.js
+++ b/packages/mangrove-solidity/scripts/mumbai/prodTests/OfferProxy/PostOfferViaProxy.js
@@ -2,7 +2,7 @@ const hre = require("hardhat");
 const { Mangrove } = require("../../../../../mangrove.js");
 
 async function main() {
-  const provider = new ethers.providers.JsonRpcProvider(hre.network.config.url);
+  const provider = ethers.getDefaultProvider(hre.network.config.url);
   if (!process.env["MUMBAI_TESTER_PRIVATE_KEY"]) {
     console.error("No tester account defined");
   }

--- a/packages/mangrove.js/CHANGELOG.md
+++ b/packages/mangrove.js/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next version
 
+- Add support for WebSocket URL's in `Mangrove.connect`
+
 # 0.5.3 (April 2022)
 
 - Adding address and other constants for test MGV token on Mumbai

--- a/packages/mangrove.js/src/cli/commands/retractCmd.ts
+++ b/packages/mangrove.js/src/cli/commands/retractCmd.ts
@@ -1,7 +1,7 @@
 import * as yargs from "yargs";
 import chalk from "chalk";
 import ethers from "ethers";
-import { WebSocketProvider } from "@ethersproject/providers";
+import { getDefaultProvider } from "@ethersproject/providers";
 import { Wallet } from "@ethersproject/wallet";
 import { NonceManager } from "@ethersproject/experimental";
 import { Mangrove, Market, Semibook } from "../..";
@@ -24,7 +24,7 @@ export const builder = (yargs) => {
 type Arguments = yargs.Arguments<ReturnType<typeof builder>>;
 
 export async function handler(argv: Arguments): Promise<void> {
-  const provider = new WebSocketProvider(argv.nodeUrl);
+  const provider = getDefaultProvider(argv.nodeUrl);
   const wallet = new Wallet(argv.privateKey, provider);
   const nonceManager = new NonceManager(wallet);
   const mangrove = await Mangrove.connect({ signer: nonceManager });

--- a/packages/mangrove.js/src/eth.ts
+++ b/packages/mangrove.js/src/eth.ts
@@ -123,7 +123,6 @@ export async function _createSigner(
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let provider: any = options.provider;
-  const isADefaultProvider = !!ethers.providers.getNetwork(provider.toString());
 
   let signer: Signer;
 
@@ -133,11 +132,7 @@ export async function _createSigner(
       contextInfo: "eth.signer",
       data: { signer: options.signer },
     });
-    if (isADefaultProvider) {
-      provider = ethers.getDefaultProvider(provider);
-    } else {
-      provider = new ethers.providers.JsonRpcProvider(provider);
-    }
+    provider = ethers.getDefaultProvider(provider);
   } else {
     logger.debug("Uses ethers' Web3Provider created from given provider", {
       contextInfo: "eth.signer",

--- a/packages/mangrove.js/test/scripts/mgvServer.js
+++ b/packages/mangrove.js/test/scripts/mgvServer.js
@@ -27,7 +27,7 @@ const main = async (opts) => {
 
   hre.config.networks.hardhat.loggingEnabled = opts.logging;
 
-  const provider = new hre.ethers.providers.JsonRpcProvider(
+  const provider = new hre.ethers.getDefaultProvider(
     `http://${host.name}:${host.port}`
   );
 

--- a/packages/mangrove.js/test/scripts/obFiller.js
+++ b/packages/mangrove.js/test/scripts/obFiller.js
@@ -30,7 +30,7 @@ const main = async () => {
     await mgvServer({ ...opts, automine: true });
   }
 
-  const provider = new hre.ethers.providers.JsonRpcProvider(_url);
+  const provider = new hre.ethers.getDefaultProvider(_url);
 
   const { Mangrove } = require("../../src");
 

--- a/packages/mangrove.js/test/scripts/obViewer.js
+++ b/packages/mangrove.js/test/scripts/obViewer.js
@@ -26,7 +26,7 @@ const main = async () => {
     await mgvServer(opts);
   }
 
-  const provider = new hre.ethers.providers.JsonRpcProvider(_url);
+  const provider = new hre.ethers.getDefaultProvider(_url);
 
   const { Mangrove } = require("../../src");
 

--- a/packages/mangrove.js/test/scripts/tester.js
+++ b/packages/mangrove.js/test/scripts/tester.js
@@ -15,7 +15,7 @@ const main = async () => {
     provider: hre.network.provider,
   });
 
-  const provider = new hre.ethers.providers.JsonRpcProvider(
+  const provider = new hre.ethers.getDefaultProvider(
     `http://${host.name}:${host.port}`
   );
 


### PR DESCRIPTION
`getDefaultProvider` provides more flexibility as it detects the protocol and constructs an appropriate provider. Thus by using that instead of `new WebSocketProvider` or `new JsonRpcProvider` the user/caller is free to select the protocol.