### PR TITLE
chore(mangrove.js): Prettify hardhatAddresses.json

### DIFF
--- a/packages/mangrove.js/writeTestDeploymentFiles.ts
+++ b/packages/mangrove.js/writeTestDeploymentFiles.ts
@@ -8,8 +8,8 @@ const mn = async () => {
   for (const { name, address } of params) {
     hardhatAddresses[name] = address;
   }
-  const json = JSON.stringify(hardhatAddresses);
-  fs.writeFileSync(JSON_FILE, json);
+  const json = JSON.stringify(hardhatAddresses, null, 2);
+  fs.writeFileSync(JSON_FILE, json + "\n");
 };
 
 mn().catch((e) => {


### PR DESCRIPTION
Write hardhatAddresses.json in the format that prettier likes to prevent constant whitespace-flux in the hardhatAddresses.json-file.

Note, that we knowingly accept writing the *nix-specific linebreak, `\n`. For one, this codebase is mainly tested to work on *nix; secondly, the alternative would be to accept possible fluctuation in the line endings of `hardAddresses.json`. This does not seem a good solution either. Ultimately, in the long run the `hardhatAddresses.json`-file will most likely not survive, so we accept this solution for now.