### PR TITLE
feat!(logging): Disable logging by default

### DIFF
--- a/packages/mangrove.js/CHANGELOG.md
+++ b/packages/mangrove.js/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next version
 
 - Remove instance aliases for stateful static methods in `Mangrove` as the scope of these was misleading: setting a value on one instance would affect all others. The removed methods are: `{get,set}Decimals`, `{get,set}DisplayedDecimals`, and `fetchDecimals`.
+- Disable logging by default. It can be turned on by calling `enableLogging()` in `util/logger`. This is a temporary workaround to prevent unwanted logging to the console until issue #220 is fixed.
 
 # 0.6.1 (May 2022)
 

--- a/packages/mangrove.js/src/util/logger.ts
+++ b/packages/mangrove.js/src/util/logger.ts
@@ -19,13 +19,26 @@ export const logdataLimiter = (data: Record<string, any>): any => {
   return inspect(data, { maxStringLength: 1000 });
 };
 
+// FIXME: Temporary dumb toggle until issue #220 is fixed
+let loggingEnabled = false;
+export function enableLogging(): void {
+  loggingEnabled = true;
+}
+export function disableLogging(): void {
+  loggingEnabled = false;
+}
+
 // FIXME: Temporary dumb implementation until issue #220 is fixed
 export const logger = {
   debug: (msg: unknown, data: unknown): void => {
-    console.log(msg + " " + stringifyData(data));
+    if (loggingEnabled) {
+      console.log(msg + " " + stringifyData(data));
+    }
   },
   warn: (msg: unknown, data: unknown): void => {
-    console.warn(msg + " " + stringifyData(data));
+    if (loggingEnabled) {
+      console.warn(msg + " " + stringifyData(data));
+    }
   },
 };
 


### PR DESCRIPTION
It can be turned on by calling `enableLogging()` in `util/logger`.

This is a temporary workaround to prevent unwanted logging to the console until issue #220 is fixed.