### PR TITLE
feat: Control Hardhat network logging with `HARDHAT_NETWORK_LOGGING_ENABLED` env var

### DIFF
--- a/packages/mangrove-solidity/config/custom-environment-variables.json
+++ b/packages/mangrove-solidity/config/custom-environment-variables.json
@@ -1,12 +1,16 @@
 {
-    "hardhat": {
-        "networks": {
-            "hardhat": {
-                "chainId": {
-                    "__name": "HARDHAT_NETWORK_CHAIN_ID",
-                    "__format": "number"
-                }
-            }
+  "hardhat": {
+    "networks": {
+      "hardhat": {
+        "chainId": {
+          "__name": "HARDHAT_NETWORK_CHAIN_ID",
+          "__format": "number"
+        },
+        "loggingEnabled": {
+          "__name": "HARDHAT_NETWORK_LOGGING_ENABLED",
+          "__format": "boolean"
         }
+      }
     }
+  }
 }


### PR DESCRIPTION
Hardhat logging for the Hardhat network can now be turned on/off by setting the env var `HARDHAT_NETWORK_LOGGING_ENABLED` to `true`/`false`.