### PR TITLE
Move from Winston to Loglevel

### DIFF
--- a/packages/bot-cleaning/README.md
+++ b/packages/bot-cleaning/README.md
@@ -60,4 +60,4 @@ It is possible to override parts of the configuration with environment variables
 
 # Logging
 
-The bot logs to `console.log` using [Winston](https://github.com/winstonjs/winston). More transports can be added by editing [src/util/logger.ts](src/util/logger.ts); Please refer to the Winston documentation for details.
+The bot logs to `console.log` using [@mangrovedao/commonlib.js].

--- a/packages/bot-cleaning/package.json
+++ b/packages/bot-cleaning/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@ethersproject/experimental": "^5.6.1",
-    "@mangrovedao/commonlib-js": "workspace:*",
+    "@mangrovedao/commonlib.js": "workspace:*",
     "@mangrovedao/mangrove.js": "workspace:*",
     "@types/big.js": "^6.1.3",
     "@types/finalhandler": "^1.1.1",

--- a/packages/bot-cleaning/src/index.ts
+++ b/packages/bot-cleaning/src/index.ts
@@ -94,7 +94,7 @@ const main = async () => {
       });
       const contextInfo = `block#=${blockNumber}`;
 
-      logger.verbose("Scheduled bot task running...", { contextInfo });
+      logger.trace("Scheduled bot task running...", { contextInfo });
       await exitIfMangroveIsKilled(mgv, contextInfo);
 
       const cleaningPromises = [];
@@ -211,6 +211,6 @@ process.on("uncaughtException", (err) => {
 });
 
 main().catch((e) => {
-  logger.exception(e);
+  logger.error(e);
   stopAndExit(ExitCode.ExceptionInMain);
 });

--- a/packages/bot-cleaning/src/util/logger.ts
+++ b/packages/bot-cleaning/src/util/logger.ts
@@ -1,4 +1,4 @@
-import { createLogger, CommonLogger, format } from "@mangrovedao/commonlib-js";
+import { createLogger, CommonLogger, format } from "@mangrovedao/commonlib.js";
 import os from "os";
 import safeStringify from "fast-safe-stringify";
 import config from "./config";

--- a/packages/bot-cleaning/src/util/logger.ts
+++ b/packages/bot-cleaning/src/util/logger.ts
@@ -1,4 +1,4 @@
-import { createLogger, BetterLogger, format } from "@mangrovedao/commonlib-js";
+import { createLogger, CommonLogger, format } from "@mangrovedao/commonlib-js";
 import os from "os";
 import safeStringify from "fast-safe-stringify";
 import config from "./config";
@@ -34,6 +34,6 @@ const consoleLogFormat = format.printf(
 );
 
 const logLevel = config.get<string>("logLevel");
-export const logger: BetterLogger = createLogger(consoleLogFormat, logLevel);
+export const logger: CommonLogger = createLogger(consoleLogFormat, logLevel);
 
 export default logger;

--- a/packages/bot-maker-noise/README.md
+++ b/packages/bot-maker-noise/README.md
@@ -83,7 +83,7 @@ Here's an example configuration file with instances of all possible configuratio
 }
 ```
 
-- `logLevel`: Sets the logging level - the bot employs the [winston](https://github.com/winstonjs/winston) logger, and it's default log-levels.
+- `logLevel`: Sets the logging level - the bot employs the logger in @mangrovedao/commonlib.js, and it's default log-levels.
 - `tokens`: A list of per-token configuration.
   - `name`: The symbol of the token.
   - `targetAllowance`: The allowance that Mangrove should be approved to transfer on behalf of the bot. On startup, this is checked and an approval tx sent if the current approval is too low.
@@ -104,4 +104,4 @@ It is possible to override parts of the configuration with environment variables
 
 # Logging
 
-The bot logs to `console.log` using [Winston](https://github.com/winstonjs/winston). More transports can be added by editing [src/util/logger.ts](src/util/logger.ts); Please refer to the Winston documentation for details.
+The bot logs to `console.log` using [@mangrovedao/commonlib.js].

--- a/packages/bot-maker-noise/package.json
+++ b/packages/bot-maker-noise/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@ethersproject/experimental": "^5.6.1",
-    "@mangrovedao/commonlib-js": "workspace:*",
+    "@mangrovedao/commonlib.js": "workspace:*",
     "@mangrovedao/mangrove.js": "workspace:*",
     "@types/big.js": "^6.1.3",
     "@types/finalhandler": "^1.1.1",

--- a/packages/bot-maker-noise/src/index.ts
+++ b/packages/bot-maker-noise/src/index.ts
@@ -329,6 +329,6 @@ process.on("uncaughtException", (err) => {
 });
 
 main().catch((e) => {
-  logger.exception(e);
+  logger.error(e);
   stopAndExit(ExitCode.ExceptionInMain);
 });

--- a/packages/bot-maker-noise/src/index.ts
+++ b/packages/bot-maker-noise/src/index.ts
@@ -4,7 +4,7 @@
  */
 
 import config from "./util/config";
-import { ErrorWithData } from "@mangrovedao/commonlib-js";
+import { ErrorWithData } from "@mangrovedao/commonlib.js";
 import { logger } from "./util/logger";
 
 import Mangrove, { MgvToken } from "@mangrovedao/mangrove.js";

--- a/packages/bot-maker-noise/src/util/logger.ts
+++ b/packages/bot-maker-noise/src/util/logger.ts
@@ -1,4 +1,4 @@
-import { createLogger, CommonLogger, format } from "@mangrovedao/commonlib-js";
+import { createLogger, CommonLogger, format } from "@mangrovedao/commonlib.js";
 import os from "os";
 import safeStringify from "fast-safe-stringify";
 import config from "./config";

--- a/packages/bot-maker-noise/src/util/logger.ts
+++ b/packages/bot-maker-noise/src/util/logger.ts
@@ -1,4 +1,4 @@
-import { createLogger, BetterLogger, format } from "@mangrovedao/commonlib-js";
+import { createLogger, CommonLogger, format } from "@mangrovedao/commonlib-js";
 import os from "os";
 import safeStringify from "fast-safe-stringify";
 import config from "./config";
@@ -37,6 +37,6 @@ const consoleLogFormat = format.printf(
 );
 
 const logLevel = config.get<string>("logLevel");
-export const logger: BetterLogger = createLogger(consoleLogFormat, logLevel);
+export const logger: CommonLogger = createLogger(consoleLogFormat, logLevel);
 
 export default logger;

--- a/packages/bot-taker-greedy/README.md
+++ b/packages/bot-taker-greedy/README.md
@@ -77,7 +77,7 @@ Here's an example configuration file with instances of all possible configuratio
 }
 ```
 
-- `logLevel`: Sets the logging level - the bot employs the [winston](https://github.com/winstonjs/winston) logger, and it's default log-levels.
+- `logLevel`: Sets the logging level - the bot employs @mangrovedao/commonlib.js, and it's default log-levels.
 - `tokens`: A list of per-token configuration.
   - `name`: The symbol of the token.
   - `targetAllowance`: The allowance that Mangrove should be approved to transfer on behalf of the bot. On startup, this is checked and an approval tx sent if the current approval is too low.
@@ -96,4 +96,4 @@ It is possible to override parts of the configuration with environment variables
 
 # Logging
 
-The bot logs to `console.log` using [Winston](https://github.com/winstonjs/winston). More transports can be added by editing [src/util/logger.ts](src/util/logger.ts); Please refer to the Winston documentation for details.
+The bot logs to `console.log` using [@mangrovedao/commonlib.js].

--- a/packages/bot-taker-greedy/package.json
+++ b/packages/bot-taker-greedy/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@ethersproject/experimental": "^5.6.1",
-    "@mangrovedao/commonlib-js": "workspace:*",
+    "@mangrovedao/commonlib.js": "workspace:*",
     "@mangrovedao/mangrove.js": "workspace:*",
     "@types/big.js": "^6.1.3",
     "@types/finalhandler": "^1.1.1",

--- a/packages/bot-taker-greedy/src/index.ts
+++ b/packages/bot-taker-greedy/src/index.ts
@@ -4,7 +4,7 @@
  */
 
 import config from "./util/config";
-import { ErrorWithData } from "@mangrovedao/commonlib-js";
+import { ErrorWithData } from "@mangrovedao/commonlib.js";
 import { logger } from "./util/logger";
 
 import Mangrove, { MgvToken } from "@mangrovedao/mangrove.js";

--- a/packages/bot-taker-greedy/src/index.ts
+++ b/packages/bot-taker-greedy/src/index.ts
@@ -278,6 +278,6 @@ process.on("uncaughtException", (err) => {
 });
 
 main().catch((e) => {
-  logger.exception(e);
+  logger.error(e);
   stopAndExit(ExitCode.ExceptionInMain);
 });

--- a/packages/bot-taker-greedy/src/util/logger.ts
+++ b/packages/bot-taker-greedy/src/util/logger.ts
@@ -1,4 +1,4 @@
-import { createLogger, CommonLogger, format } from "@mangrovedao/commonlib-js";
+import { createLogger, CommonLogger, format } from "@mangrovedao/commonlib.js";
 import os from "os";
 import safeStringify from "fast-safe-stringify";
 import config from "./config";

--- a/packages/bot-taker-greedy/src/util/logger.ts
+++ b/packages/bot-taker-greedy/src/util/logger.ts
@@ -1,4 +1,4 @@
-import { createLogger, BetterLogger, format } from "@mangrovedao/commonlib-js";
+import { createLogger, CommonLogger, format } from "@mangrovedao/commonlib-js";
 import os from "os";
 import safeStringify from "fast-safe-stringify";
 import config from "./config";
@@ -37,6 +37,6 @@ const consoleLogFormat = format.printf(
 );
 
 const logLevel = config.get<string>("logLevel");
-export const logger: BetterLogger = createLogger(consoleLogFormat, logLevel);
+export const logger: CommonLogger = createLogger(consoleLogFormat, logLevel);
 
 export default logger;

--- a/packages/bot-template/README.md
+++ b/packages/bot-template/README.md
@@ -61,11 +61,11 @@ Here's an example configuration file with instances of all possible configuratio
 }
 ```
 
-- `logLevel`: Sets the logging level - the bot employs the [winston](https://github.com/winstonjs/winston) logger, and it's default log-levels.
+- `logLevel`: Sets the logging level - the bot employs @mangrovedao/comonlib.js, and it's default log-levels.
 - TODO: Add other configuration options here.
 
 It is possible to override parts of the configuration with environment variables. This is controlled by [./config/custom-environment-variables.json](./config/custom-environment-variables.json). The structure of this file mirrors the configuration structure but with names of environment variables in the places where these can override a part of the configuration.
 
 # Logging
 
-The bot logs to `console.log` using [Winston](https://github.com/winstonjs/winston). More transports can be added by editing [src/util/logger.ts](src/util/logger.ts); Please refer to the Winston documentation for details.
+The bot logs to `console.log` using [@mangrovedao/commonlib.js].

--- a/packages/bot-template/config/default.json
+++ b/packages/bot-template/config/default.json
@@ -1,3 +1,3 @@
 {
-  "logLevel": "verbose"
+  "logLevel": "debug"
 }

--- a/packages/bot-template/package.json
+++ b/packages/bot-template/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@ethersproject/experimental": "^5.6.1",
-    "@mangrovedao/commonlib-js": "workspace:*",
+    "@mangrovedao/commonlib.js": "workspace:*",
     "@mangrovedao/mangrove.js": "workspace:*",
     "@types/big.js": "^6.1.3",
     "@types/finalhandler": "^1.1.1",

--- a/packages/bot-template/src/index.ts
+++ b/packages/bot-template/src/index.ts
@@ -82,6 +82,6 @@ process.on("uncaughtException", (err) => {
 });
 
 main().catch((e) => {
-  logger.exception(e);
+  logger.error(e);
   stopAndExit(ExitCode.ExceptionInMain);
 });

--- a/packages/bot-template/src/util/logger.ts
+++ b/packages/bot-template/src/util/logger.ts
@@ -1,4 +1,4 @@
-import { createLogger, BetterLogger, format } from "@mangrovedao/commonlib-js";
+import { createLogger, CommonLogger, format } from "@mangrovedao/commonlib-js";
 import os from "os";
 import safeStringify from "fast-safe-stringify";
 import config from "./config";
@@ -23,6 +23,6 @@ const consoleLogFormat = format.printf(
 );
 
 const logLevel = config.get<string>("logLevel");
-export const logger: BetterLogger = createLogger(consoleLogFormat, logLevel);
+export const logger: CommonLogger = createLogger(consoleLogFormat, logLevel);
 
 export default logger;

--- a/packages/bot-template/src/util/logger.ts
+++ b/packages/bot-template/src/util/logger.ts
@@ -1,10 +1,10 @@
-import { createLogger, CommonLogger, format } from "@mangrovedao/commonlib-js";
+import { createLogger, CommonLogger, format } from "@mangrovedao/commonlib.js";
 import os from "os";
 import safeStringify from "fast-safe-stringify";
 import config from "./config";
 
 /* NOTE:
- * This is a basic usage and setup of a console logger from @mangrovedao/commonlib-js
+ * This is a basic usage and setup of a console logger from @mangrovedao/commonlib.js
  * Extend at your leisure; see other bots for examples.
  */
 

--- a/packages/bot-updategas/README.md
+++ b/packages/bot-updategas/README.md
@@ -57,7 +57,7 @@ Here's an example configuration file with instances of all possible configuratio
 }
 ```
 
-- `logLevel`: Sets the logging level - the bot employs the [winston](https://github.com/winstonjs/winston) logger, and it's default log-levels.
+- `logLevel`: Sets the logging level - the bot employs @mangrovedao/commonlib.js, and it's default log-levels.
 - `acceptableGasGapToOracle`: If the difference between Mangrove's current gas price and the standard gas price reported by the oracle is above this threshold a gas price update will be sent to Mangrove's gas price oracle.
 - `constantOracleGasPrice`: A constant gas price to be returned by this bot. _This setting overrides a given `oracleURL`._
 - `oracleURL`: URL for an external oracle - expects a JSON REST endpoint a la <https://gasstation-mainnet.matic.network/>. _This setting is only used if `constantOracleGasPrice` is not given._
@@ -68,4 +68,4 @@ It is possible to override parts of the configuration with environment variables
 
 # Logging
 
-The bot logs to `console.log` using [Winston](https://github.com/winstonjs/winston). More transports can be added by editing [src/util/logger.ts](src/util/logger.ts); Please refer to the Winston documentation for details.
+The bot logs to `console.log` using [@mangrovedao/commonlib.js].

--- a/packages/bot-updategas/config/default.json
+++ b/packages/bot-updategas/config/default.json
@@ -1,5 +1,5 @@
 {
-  "logLevel": "verbose",
+  "logLevel": "debug",
   "acceptableGasGapToOracle": 0.5,
   "oracleURL": "https://gasstation-mainnet.matic.network/",
   "oracleURL_Key": "standard",

--- a/packages/bot-updategas/package.json
+++ b/packages/bot-updategas/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@ethersproject/experimental": "^5.6.1",
-    "@mangrovedao/commonlib-js": "workspace:*",
+    "@mangrovedao/commonlib.js": "workspace:*",
     "@mangrovedao/mangrove.js": "workspace:*",
     "@types/big.js": "^6.1.3",
     "@types/finalhandler": "^1.1.1",

--- a/packages/bot-updategas/src/GasUpdater.ts
+++ b/packages/bot-updategas/src/GasUpdater.ts
@@ -103,12 +103,12 @@ export class GasUpdater {
         );
 
       if (shouldUpdateGasPrice) {
-        logger.verbose(`Determined gas price update needed. `, {
+        logger.debug(`Determined gas price update needed. `, {
           data: newGasPrice,
         });
         await this.#updateMangroveGasPrice(newGasPrice);
       } else {
-        logger.verbose(`Determined gas price update not needed.`);
+        logger.debug(`Determined gas price update not needed.`);
       }
     } else {
       const url = this.#oracleURL;

--- a/packages/bot-updategas/src/index.ts
+++ b/packages/bot-updategas/src/index.ts
@@ -76,7 +76,7 @@ const main = async () => {
         return -1;
       });
 
-      logger.verbose(`Scheduled bot task running on block ${blockNumber}...`);
+      logger.debug(`Scheduled bot task running on block ${blockNumber}...`);
       await exitIfMangroveIsKilled(mgv, blockNumber);
       await gasUpdater.checkSetGasprice();
     },
@@ -232,6 +232,6 @@ process.on("uncaughtException", (err) => {
 });
 
 main().catch((e) => {
-  logger.exception(e);
+  logger.error(e);
   stopAndExit(ExitCode.ExceptionInMain);
 });

--- a/packages/bot-updategas/src/util/logger.ts
+++ b/packages/bot-updategas/src/util/logger.ts
@@ -1,4 +1,4 @@
-import { createLogger, BetterLogger, format } from "@mangrovedao/commonlib-js";
+import { createLogger, CommonLogger, format } from "@mangrovedao/commonlib-js";
 import os from "os";
 import safeStringify from "fast-safe-stringify";
 import config from "./config";
@@ -18,6 +18,6 @@ const consoleLogFormat = format.printf(
 );
 
 const logLevel = config.get<string>("logLevel");
-export const logger: BetterLogger = createLogger(consoleLogFormat, logLevel);
+export const logger: CommonLogger = createLogger(consoleLogFormat, logLevel);
 
 export default logger;

--- a/packages/bot-updategas/src/util/logger.ts
+++ b/packages/bot-updategas/src/util/logger.ts
@@ -1,4 +1,4 @@
-import { createLogger, CommonLogger, format } from "@mangrovedao/commonlib-js";
+import { createLogger, CommonLogger, format } from "@mangrovedao/commonlib.js";
 import os from "os";
 import safeStringify from "fast-safe-stringify";
 import config from "./config";

--- a/packages/commonlib.js/README.md
+++ b/packages/commonlib.js/README.md
@@ -7,14 +7,14 @@ This package is not intended for use outside of the Mangrove monorepo.
 Inside the monorepo, dependencies to this package can be added using the `workspace:*` version range, e.g:
 
 ```bash
-$ yarn add "@mangrovedao/commonlib-js@workspace:*"
+$ yarn add "@mangrovedao/commonlib.js@workspace:*"
 ```
 
 which will add
 
 ```json
   "dependencies": {
-    "@mangrovedao/commonlib-js": "workspace:*"
+    "@mangrovedao/commonlib.js": "workspace:*"
   }
 ```
 

--- a/packages/commonlib.js/mocha-multi-reporters.json
+++ b/packages/commonlib.js/mocha-multi-reporters.json
@@ -1,6 +1,6 @@
 {
   "reporterEnabled": "spec, @espendk/json-file-reporter",
   "espendkJsonFileReporterReporterOptions": {
-    "output": "commonlib-js-mocha-test-report.json"
+    "output": "mocha-test-report.json"
   }
 }

--- a/packages/commonlib.js/package.json
+++ b/packages/commonlib.js/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mangrovedao/commonlib-js",
+  "name": "@mangrovedao/commonlib.js",
   "version": "0.0.2",
   "author": "Mangrove DAO",
   "description": "Common javascript and typescript library code employed in the Mangrove mono-repo.",

--- a/packages/commonlib.js/package.json
+++ b/packages/commonlib.js/package.json
@@ -25,11 +25,13 @@
     "**/*": "prettier --write --ignore-unknown"
   },
   "dependencies": {
+    "@types/triple-beam": "^1.3.2",
     "config": "^3.3.7",
     "dotenv-flow": "^3.2.0",
     "fast-safe-stringify": "^2.1.1",
     "json-truncate": "^3.0.0",
-    "winston": "^3.7.2"
+    "logform": "^2.4.0",
+    "triple-beam": "^1.3.0"
   },
   "devDependencies": {
     "@espendk/json-file-reporter": "^1.4.2",

--- a/packages/commonlib.js/package.json
+++ b/packages/commonlib.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mangrovedao/commonlib-js",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": "Mangrove DAO",
   "description": "Common javascript and typescript library code employed in the Mangrove mono-repo.",
   "license": "BSD-2-Clause",

--- a/packages/commonlib.js/package.json
+++ b/packages/commonlib.js/package.json
@@ -31,6 +31,7 @@
     "fast-safe-stringify": "^2.1.1",
     "json-truncate": "^3.0.0",
     "logform": "^2.4.0",
+    "loglevel": "^1.8.0",
     "triple-beam": "^1.3.0"
   },
   "devDependencies": {

--- a/packages/commonlib.js/src/index.ts
+++ b/packages/commonlib.js/src/index.ts
@@ -1,19 +1,12 @@
 import { ErrorWithData } from "./errorWithData";
-import {
-  BetterLogger,
-  createLogger,
-  logdataLimiter,
-  format,
-  transports,
-} from "./logger";
+import { CommonLogger, createLogger, logdataLimiter, format } from "./logger";
 import { sleep } from "./promiseUtil";
 
 export {
   ErrorWithData,
-  BetterLogger,
+  CommonLogger,
   createLogger,
   logdataLimiter,
   format,
-  transports,
   sleep,
 };

--- a/packages/commonlib.js/src/logger.ts
+++ b/packages/commonlib.js/src/logger.ts
@@ -40,7 +40,6 @@ const levelConfig = {
 export const createLogger = (
   consoleFormatLogger: Format,
   logLevel: string
-  //additionalTransports: Transport[] = []
 ): CommonLogger => {
   /* Expose winston-style interface to the logger */
   // generate fresh logger

--- a/packages/commonlib.js/src/logger.ts
+++ b/packages/commonlib.js/src/logger.ts
@@ -1,58 +1,102 @@
-import {
-  createLogger as winstonCreateLogger,
-  format,
-  transports,
-  Logger,
-} from "winston";
-import Transport from "winston-transport";
-import { ErrorWithData } from "./errorWithData";
-import { Format } from "logform";
+import { Format, format } from "logform";
 import truncate from "json-truncate";
+import loglevel from "loglevel";
+import { MESSAGE, LEVEL } from "triple-beam";
 
 export type LogMetadata = {
   data?: Object;
   stack?: string;
 };
 
-export interface BetterLogger extends Logger {
-  exception: (error: Error, data?: Object) => BetterLogger;
-}
+// wrapping logger type to prepare for future backend logging swaps
+export interface CommonLogger extends loglevel.Logger {}
+
+// These are loglevel's levels
+const levels = {
+  trace: 0,
+  debug: 1,
+  info: 2,
+  warn: 3,
+  error: 4,
+  silent: 5,
+};
+
+const invertedLevels = Object.fromEntries(
+  Object.entries(levels).map((a) => a.reverse())
+);
+
+const levelConfig = {
+  levels,
+  invertedLevels,
+  colors: {
+    trace: "cyan",
+    debug: "blue",
+    info: "green",
+    warn: "yellow",
+    error: "red",
+  },
+};
 
 export const createLogger = (
   consoleFormatLogger: Format,
-  logLevel: string,
-  additionalTransports: Transport[] = []
-): BetterLogger => {
-  const consoleTransport = new transports.Console({
-    level: logLevel,
-    handleExceptions: true,
-    format: format.combine(
-      format.colorize(),
+  logLevel: string
+  //additionalTransports: Transport[] = []
+): CommonLogger => {
+  /* Expose winston-style interface to the logger */
+  // generate fresh logger
+  const logger = loglevel.getLogger(Symbol());
+  // remember default log method generator
+  var originalFactory = logger.methodFactory;
+
+  // configure colorizer
+  const opts = {
+    colors: {
+      error: "red",
+      debug: "blue",
+      warn: "yellow",
+      data: "grey",
+      info: "green",
+      verbose: "cyan",
+      silly: "magenta",
+      custom: "yellow",
+    },
+  };
+  const colorizer = format.colorize(opts);
+
+  // generate new logging methods
+  logger.methodFactory = function (methodName, logLevel, loggerName) {
+    // remember default log method
+    var rawMethod = originalFactory(methodName, logLevel, loggerName);
+
+    // create formatter with logform
+    const thisFormat = format.combine(
+      colorizer,
       format.splat(),
       format.timestamp(),
+      format.errors({ stack: true }),
       consoleFormatLogger
-    ),
-  });
-  additionalTransports.push(consoleTransport);
+    );
 
-  const theLogger = winstonCreateLogger({
-    transports: additionalTransports,
-  }) as BetterLogger;
+    // generate actual logging method
+    return function (message, metadata) {
+      // send log info to formatter
+      const formatted = thisFormat.transform({
+        // convert to logLevel string, since that is what logform expects
+        level: levelConfig.invertedLevels[logLevel],
+        [LEVEL]: levelConfig.invertedLevels[logLevel],
+        message,
+        ...metadata,
+      });
 
-  // Monkey patching Winston because it incorrectly logs `Error` instances even in 2021
-  // Related issue: https://github.com/winstonjs/winston/issues/1498
-  theLogger.exception = function (error: Error, data?: Object) {
-    const message = error.message;
-    const stack = error.stack;
-
-    if (error instanceof ErrorWithData) {
-      data = error.data;
-    }
-
-    return this.error(message, { stack: stack, data: data }) as BetterLogger;
+      if (typeof formatted != "boolean") {
+        // retrieve formatted message, send to raw method
+        rawMethod(formatted[MESSAGE as any]);
+      }
+    };
   };
-
-  return theLogger as BetterLogger;
+  // update logging methods
+  logger.setLevel(logger.getLevel());
+  return logger as CommonLogger;
 };
 
 // This processor must be used when logging large objects, because of Winston memory consumption in that case
@@ -60,6 +104,6 @@ export const logdataLimiter = (data: Object): string => {
   return truncate(data, { maxDepth: 3, replace: "[Truncated]" });
 };
 
-export { format, transports };
+export { format };
 
 export default createLogger;

--- a/packages/commonlib.js/src/logger.ts
+++ b/packages/commonlib.js/src/logger.ts
@@ -93,8 +93,12 @@ export const createLogger = (
       }
     };
   };
-  // update logging methods
-  logger.setLevel(logger.getLevel());
+  // simultaneously set logger level as low as possible & apply new methodFactory.
+  const logLevelNum = (levels as any)[logLevel.toLowerCase()];
+  if (logLevelNum === undefined) {
+    throw Error(`Unknown logLevel: ${logLevel}`);
+  }
+  logger.setLevel(logLevelNum);
   return logger as CommonLogger;
 };
 

--- a/packages/mangrove-solidity/config/default.js
+++ b/packages/mangrove-solidity/config/default.js
@@ -53,11 +53,6 @@ config.hardhat = {
         enabled: true,
         runs: 20000,
       },
-      outputSelection: {
-        "*": {
-          "*": ["storageLayout"],
-        },
-      },
     },
   },
   paths: {

--- a/packages/mangrove-solidity/config/default.js
+++ b/packages/mangrove-solidity/config/default.js
@@ -53,6 +53,11 @@ config.hardhat = {
         enabled: true,
         runs: 20000,
       },
+      outputSelection: {
+        "*": {
+          "*": ["storageLayout"],
+        },
+      },
     },
   },
   paths: {

--- a/packages/mangrove.js/package.json
+++ b/packages/mangrove.js/package.json
@@ -72,7 +72,7 @@
     "@ethersproject/bytes": "^5.0.0",
     "@ethersproject/hardware-wallets": "^5.6.0",
     "@ethersproject/providers": "^5.6.4",
-    "@mangrovedao/commonlib-js": "workspace:*",
+    "@mangrovedao/commonlib.js": "workspace:*",
     "@mangrovedao/hardhat-utils": "workspace:*",
     "@mangrovedao/mangrove-solidity": "workspace:*",
     "@nomiclabs/hardhat-ethers": "^2.0.5",

--- a/packages/mangrove.js/package.json
+++ b/packages/mangrove.js/package.json
@@ -72,6 +72,7 @@
     "@ethersproject/bytes": "^5.0.0",
     "@ethersproject/hardware-wallets": "^5.6.0",
     "@ethersproject/providers": "^5.6.4",
+    "@mangrovedao/commonlib-js": "0.0.2",
     "@mangrovedao/hardhat-utils": "workspace:*",
     "@mangrovedao/mangrove-solidity": "workspace:*",
     "@nomiclabs/hardhat-ethers": "^2.0.5",

--- a/packages/mangrove.js/package.json
+++ b/packages/mangrove.js/package.json
@@ -72,7 +72,7 @@
     "@ethersproject/bytes": "^5.0.0",
     "@ethersproject/hardware-wallets": "^5.6.0",
     "@ethersproject/providers": "^5.6.4",
-    "@mangrovedao/commonlib-js": "0.0.2",
+    "@mangrovedao/commonlib-js": "workspace:*",
     "@mangrovedao/hardhat-utils": "workspace:*",
     "@mangrovedao/mangrove-solidity": "workspace:*",
     "@nomiclabs/hardhat-ethers": "^2.0.5",

--- a/packages/mangrove.js/src/util/logger.ts
+++ b/packages/mangrove.js/src/util/logger.ts
@@ -1,5 +1,5 @@
 import inspect from "object-inspect";
-import { createLogger, CommonLogger, format } from "@mangrovedao/commonlib-js";
+import { createLogger, CommonLogger, format } from "@mangrovedao/commonlib.js";
 import os from "os";
 
 const stringifyData = (data) => {

--- a/packages/mangrove.js/src/util/logger.ts
+++ b/packages/mangrove.js/src/util/logger.ts
@@ -1,13 +1,6 @@
-// FIXME: The logger has been stunted by removing the dependency to commonlib.js
-//        as a temporary workaround for issue #220 and issue #226.
-//        To avoid reverting a merge commit and the burden of maintaining that old feature branch,
-//        we have opted to keep most of the logging code but only support simplified logging to console.
-//
-//        For references on why we want to avoid revert merge commits:
-//          Long (Linus): https://github.com/git/git/blob/master/Documentation/howto/revert-a-faulty-merge.txt
-//          Short: https://www.datree.io/resources/git-undo-merge
-
 import inspect from "object-inspect";
+import { createLogger, CommonLogger, format } from "@mangrovedao/commonlib-js";
+import os from "os";
 
 const stringifyData = (data) => {
   if (typeof data == "string") return data;
@@ -20,7 +13,7 @@ export const logdataLimiter = (data: Record<string, any>): any => {
 };
 
 // FIXME: Temporary dumb toggle until issue #220 is fixed
-let loggingEnabled = false;
+let loggingEnabled = true;
 export function enableLogging(): void {
   loggingEnabled = true;
 }
@@ -28,18 +21,25 @@ export function disableLogging(): void {
   loggingEnabled = false;
 }
 
-// FIXME: Temporary dumb implementation until issue #220 is fixed
-export const logger = {
-  debug: (msg: unknown, data: unknown): void => {
-    if (loggingEnabled) {
-      console.log(msg + " " + stringifyData(data));
+const consoleLogFormat = format.printf(
+  ({ level, message, timestamp, ...metadata }) => {
+    console.log("in there");
+    let msg = `${timestamp} [${level}] `;
+    if (metadata.contextInfo !== undefined) {
+      msg += `[${metadata.contextInfo}] `;
     }
-  },
-  warn: (msg: unknown, data: unknown): void => {
-    if (loggingEnabled) {
-      console.warn(msg + " " + stringifyData(data));
+    msg += message;
+    if (metadata.data !== undefined) {
+      msg += ` | data: ${stringifyData(metadata.data)}`;
     }
-  },
-};
+    if (metadata.stack !== undefined) {
+      msg += `${os.EOL}${metadata.stack}`;
+    }
+    return msg;
+  }
+);
+
+const logLevel = "debug";
+export const logger: CommonLogger = createLogger(consoleLogFormat, logLevel);
 
 export default logger;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1484,7 +1484,7 @@ __metadata:
     "@espendk/json-file-reporter": ^1.4.2
     "@ethersproject/experimental": ^5.6.1
     "@ethersproject/hardware-wallets": ^5.6.0
-    "@mangrovedao/commonlib-js": "workspace:*"
+    "@mangrovedao/commonlib.js": "workspace:*"
     "@mangrovedao/hardhat-utils": "workspace:*"
     "@mangrovedao/mangrove-solidity": "workspace:*"
     "@mangrovedao/mangrove.js": "workspace:*"
@@ -1537,7 +1537,7 @@ __metadata:
     "@espendk/json-file-reporter": ^1.4.2
     "@ethersproject/experimental": ^5.6.1
     "@ethersproject/hardware-wallets": ^5.6.0
-    "@mangrovedao/commonlib-js": "workspace:*"
+    "@mangrovedao/commonlib.js": "workspace:*"
     "@mangrovedao/hardhat-utils": "workspace:*"
     "@mangrovedao/mangrove-solidity": "workspace:*"
     "@mangrovedao/mangrove.js": "workspace:*"
@@ -1590,7 +1590,7 @@ __metadata:
     "@espendk/json-file-reporter": ^1.4.2
     "@ethersproject/experimental": ^5.6.1
     "@ethersproject/hardware-wallets": ^5.6.0
-    "@mangrovedao/commonlib-js": "workspace:*"
+    "@mangrovedao/commonlib.js": "workspace:*"
     "@mangrovedao/hardhat-utils": "workspace:*"
     "@mangrovedao/mangrove-solidity": "workspace:*"
     "@mangrovedao/mangrove.js": "workspace:*"
@@ -1644,7 +1644,7 @@ __metadata:
     "@espendk/json-file-reporter": ^1.4.2
     "@ethersproject/experimental": ^5.6.1
     "@ethersproject/hardware-wallets": ^5.6.0
-    "@mangrovedao/commonlib-js": "workspace:*"
+    "@mangrovedao/commonlib.js": "workspace:*"
     "@mangrovedao/hardhat-utils": "workspace:*"
     "@mangrovedao/mangrove-solidity": "workspace:*"
     "@mangrovedao/mangrove.js": "workspace:*"
@@ -1696,7 +1696,7 @@ __metadata:
     "@espendk/json-file-reporter": ^1.4.2
     "@ethersproject/experimental": ^5.6.1
     "@ethersproject/hardware-wallets": ^5.6.0
-    "@mangrovedao/commonlib-js": "workspace:*"
+    "@mangrovedao/commonlib.js": "workspace:*"
     "@mangrovedao/hardhat-utils": "workspace:*"
     "@mangrovedao/mangrove-solidity": "workspace:*"
     "@mangrovedao/mangrove.js": "workspace:*"
@@ -1743,9 +1743,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@mangrovedao/commonlib-js@0.0.2, @mangrovedao/commonlib-js@workspace:*, @mangrovedao/commonlib-js@workspace:packages/commonlib.js":
+"@mangrovedao/commonlib.js@workspace:*, @mangrovedao/commonlib.js@workspace:packages/commonlib.js":
   version: 0.0.0-use.local
-  resolution: "@mangrovedao/commonlib-js@workspace:packages/commonlib.js"
+  resolution: "@mangrovedao/commonlib.js@workspace:packages/commonlib.js"
   dependencies:
     "@espendk/json-file-reporter": ^1.4.2
     "@types/config": ^0.0.41
@@ -1884,7 +1884,7 @@ __metadata:
     "@ethersproject/experimental": ^5.6.1
     "@ethersproject/hardware-wallets": ^5.6.0
     "@ethersproject/providers": ^5.6.4
-    "@mangrovedao/commonlib-js": 0.0.2
+    "@mangrovedao/commonlib.js": "workspace:*"
     "@mangrovedao/hardhat-utils": "workspace:*"
     "@mangrovedao/mangrove-solidity": "workspace:*"
     "@nomiclabs/hardhat-ethers": ^2.0.5

--- a/yarn.lock
+++ b/yarn.lock
@@ -1763,6 +1763,7 @@ __metadata:
     json-truncate: ^3.0.0
     lint-staged: ^12.4.1
     logform: ^2.4.0
+    loglevel: ^1.8.0
     mocha: ^10.0.0
     mocha-multi-reporters: ^1.5.1
     prettier: 2.6.2
@@ -7011,6 +7012,13 @@ fsevents@~2.3.2:
   version: 1.7.1
   resolution: "loglevel@npm:1.7.1"
   checksum: 715a4ae69ad75d4d3bd04e4f6e9edbc4cae4db34d1e7f54f426d8cebe2dd9fef891ca3789e839d927cdbc5fad73d789e998db0af2f11f4c40219c272bc923823
+  languageName: node
+  linkType: hard
+
+"loglevel@npm:^1.8.0":
+  version: 1.8.0
+  resolution: "loglevel@npm:1.8.0"
+  checksum: 41aeea17de24aba8dba68084a31fe9189648bce4f39c1277e021bb276c3c53a75b0d337395919cf271068ad40ecefabad0e4fdeb4a8f11908beee532b898f4a7
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -286,17 +286,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@dabh/diagnostics@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "@dabh/diagnostics@npm:2.0.2"
-  dependencies:
-    colorspace: 1.1.x
-    enabled: 2.0.x
-    kuler: ^2.0.0
-  checksum: 4d95cc31249a840b6cc3dba3dc4345a9295265413456068a0d07b69fa0ec6a5a5bc2c39e56ec04c6509ac1f4d9c17fc80baaaddd5caa1abcdd3aaeffe2b63cec
-  languageName: node
-  linkType: hard
-
 "@eslint/eslintrc@npm:^0.4.3":
   version: 0.4.3
   resolution: "@eslint/eslintrc@npm:0.4.3"
@@ -1763,6 +1752,7 @@ __metadata:
     "@types/dotenv-flow": ^3.2.0
     "@types/mocha": ^9.0.0
     "@types/node": ^17.0.31
+    "@types/triple-beam": ^1.3.2
     "@typescript-eslint/eslint-plugin": ^5.22.0
     "@typescript-eslint/parser": ^5.22.0
     config: ^3.3.7
@@ -1772,14 +1762,15 @@ __metadata:
     fast-safe-stringify: ^2.1.1
     json-truncate: ^3.0.0
     lint-staged: ^12.4.1
+    logform: ^2.4.0
     mocha: ^10.0.0
     mocha-multi-reporters: ^1.5.1
     prettier: 2.6.2
     prettier-eslint: ^13.0.0
     rimraf: ^3.0.2
+    triple-beam: ^1.3.0
     ts-node: ^10.2.1
     typescript: ^4.4.2
-    winston: ^3.7.2
   languageName: unknown
   linkType: soft
 
@@ -2505,6 +2496,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/triple-beam@npm:^1.3.2":
+  version: 1.3.2
+  resolution: "@types/triple-beam@npm:1.3.2"
+  checksum: dd7b4a563fb710abc992e5d59eac481bed9e303fada2e276e37b00be31c392e03300ee468e57761e616512872e77935f92472877d0704a19688d15a726cee17b
+  languageName: node
+  linkType: hard
+
 "@types/yargs-parser@npm:*":
   version: 20.2.1
   resolution: "@types/yargs-parser@npm:20.2.1"
@@ -3125,13 +3123,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"async@npm:^3.2.3":
-  version: 3.2.3
-  resolution: "async@npm:3.2.3"
-  checksum: c4bee57ab2249af3dc83ca3ef9acfa8e822c0d5e5aa41bae3eaf7f673648343cd64ecd7d26091ffd357f3f044428b17b5f00098494b6cf8b6b3e9681f0636ca1
-  languageName: node
-  linkType: hard
-
 "asynckit@npm:^0.4.0":
   version: 0.4.0
   resolution: "asynckit@npm:0.4.0"
@@ -3742,7 +3733,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-convert@npm:^1.9.0, color-convert@npm:^1.9.3":
+"color-convert@npm:^1.9.0":
   version: 1.9.3
   resolution: "color-convert@npm:1.9.3"
   dependencies:
@@ -3767,30 +3758,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-name@npm:^1.0.0, color-name@npm:~1.1.4":
+"color-name@npm:~1.1.4":
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
   checksum: b0445859521eb4021cd0fb0cc1a75cecf67fceecae89b63f62b201cca8d345baf8b952c966862a9d9a2632987d4f6581f0ec8d957dfacece86f0a7919316f610
-  languageName: node
-  linkType: hard
-
-"color-string@npm:^1.6.0":
-  version: 1.6.0
-  resolution: "color-string@npm:1.6.0"
-  dependencies:
-    color-name: ^1.0.0
-    simple-swizzle: ^0.2.2
-  checksum: 33466a65277dd3d4ce24ef1991b47069292f75d1a43b0d2e7ea43076ba793728e965d50deed2b523f35519f4995a908253fcbcc774baceae8e439bc78c02e850
-  languageName: node
-  linkType: hard
-
-"color@npm:^3.1.3":
-  version: 3.2.1
-  resolution: "color@npm:3.2.1"
-  dependencies:
-    color-convert: ^1.9.3
-    color-string: ^1.6.0
-  checksum: f81220e8b774d35865c2561be921f5652117638dcda7ca4029262046e37fc2444ac7bbfdd110cf1fd9c074a4ee5eda8f85944ffbdda26186b602dd9bb05f6400
   languageName: node
   linkType: hard
 
@@ -3798,16 +3769,6 @@ __metadata:
   version: 2.0.16
   resolution: "colorette@npm:2.0.16"
   checksum: cd55596a3a2d1071c1a28eee7fd8a5387593ff1bd10a3e8d0a6221499311fe34a9f2b9272d77c391e0e003dcdc8934fb2f8d106e7ef1f7516f8060c901d41a27
-  languageName: node
-  linkType: hard
-
-"colorspace@npm:1.1.x":
-  version: 1.1.4
-  resolution: "colorspace@npm:1.1.4"
-  dependencies:
-    color: ^3.1.3
-    text-hex: 1.0.x
-  checksum: bb3934ef3c417e961e6d03d7ca60ea6e175947029bfadfcdb65109b01881a1c0ecf9c2b0b59abcd0ee4a0d7c1eae93beed01b0e65848936472270a0b341ebce8
   languageName: node
   linkType: hard
 
@@ -4371,13 +4332,6 @@ __metadata:
   version: 9.2.2
   resolution: "emoji-regex@npm:9.2.2"
   checksum: 8487182da74aabd810ac6d6f1994111dfc0e331b01271ae01ec1eb0ad7b5ecc2bbbbd2f053c05cb55a1ac30449527d819bbfbf0e3de1023db308cbcb47f86601
-  languageName: node
-  linkType: hard
-
-"enabled@npm:2.0.x":
-  version: 2.0.0
-  resolution: "enabled@npm:2.0.0"
-  checksum: 9d256d89f4e8a46ff988c6a79b22fa814b4ffd82826c4fdacd9b42e9b9465709d3b748866d0ab4d442dfc6002d81de7f7b384146ccd1681f6a7f868d2acca063
   languageName: node
   linkType: hard
 
@@ -5196,13 +5150,6 @@ __metadata:
   dependencies:
     imul: ^1.0.0
   checksum: c465344d4f169eaf10d45c33949a1e7a633f09dba2ac7063ce8ae8be743df5979d708f7f24900163589f047f5194ac5fc2476177ce31175e8805adfa7b8fb7a4
-  languageName: node
-  linkType: hard
-
-"fn.name@npm:1.x.x":
-  version: 1.1.0
-  resolution: "fn.name@npm:1.1.0"
-  checksum: e357144f48cfc9a7f52a82bbc6c23df7c8de639fce049cac41d41d62cabb740cdb9f14eddc6485e29c933104455bdd7a69bb14a9012cef9cd4fa252a4d0cf293
   languageName: node
   linkType: hard
 
@@ -6095,13 +6042,6 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
-"is-arrayish@npm:^0.3.1":
-  version: 0.3.2
-  resolution: "is-arrayish@npm:0.3.2"
-  checksum: 977e64f54d91c8f169b59afcd80ff19227e9f5c791fa28fa2e5bce355cbaf6c2c356711b734656e80c9dd4a854dd7efcf7894402f1031dfc5de5d620775b4d5f
-  languageName: node
-  linkType: hard
-
 "is-bigint@npm:^1.0.1":
   version: 1.0.4
   resolution: "is-bigint@npm:1.0.4"
@@ -6669,13 +6609,6 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
-"kuler@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "kuler@npm:2.0.0"
-  checksum: 9e10b5a1659f9ed8761d38df3c35effabffbd19fc6107324095238e4ef0ff044392cae9ac64a1c2dda26e532426485342226b93806bd97504b174b0dcf04ed81
-  languageName: node
-  linkType: hard
-
 "level-codec@npm:^9.0.0":
   version: 9.0.2
   resolution: "level-codec@npm:9.0.2"
@@ -7051,7 +6984,7 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
-"logform@npm:^2.3.2, logform@npm:^2.4.0":
+"logform@npm:^2.4.0":
   version: 2.4.0
   resolution: "logform@npm:2.4.0"
   dependencies:
@@ -8183,15 +8116,6 @@ fsevents@~2.3.2:
   dependencies:
     wrappy: 1
   checksum: cd0a88501333edd640d95f0d2700fbde6bff20b3d4d9bdc521bdd31af0656b5706570d6c6afe532045a20bb8dc0849f8332d6f2a416e0ba6d3d3b98806c7db68
-  languageName: node
-  linkType: hard
-
-"one-time@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "one-time@npm:1.0.0"
-  dependencies:
-    fn.name: 1.x.x
-  checksum: fd008d7e992bdec1c67f53a2f9b46381ee12a9b8c309f88b21f0223546003fb47e8ad7c1fd5843751920a8d276c63bd4b45670ef80c61fb3e07dbccc962b5c7d
   languageName: node
   linkType: hard
 
@@ -9463,15 +9387,6 @@ resolve@1.17.0:
   languageName: node
   linkType: hard
 
-"simple-swizzle@npm:^0.2.2":
-  version: 0.2.2
-  resolution: "simple-swizzle@npm:0.2.2"
-  dependencies:
-    is-arrayish: ^0.3.1
-  checksum: a7f3f2ab5c76c4472d5c578df892e857323e452d9f392e1b5cf74b74db66e6294a1e1b8b390b519fa1b96b5b613f2a37db6cffef52c3f1f8f3c5ea64eb2d54c0
-  languageName: node
-  linkType: hard
-
 "slash@npm:^3.0.0":
   version: 3.0.0
   resolution: "slash@npm:3.0.0"
@@ -9702,13 +9617,6 @@ resolve@1.17.0:
   dependencies:
     minipass: ^3.1.1
   checksum: bc447f5af814fa9713aa201ec2522208ae0f4d8f3bda7a1f445a797c7b929a02720436ff7c478fb5edc4045adb02b1b88d2341b436a80798734e2494f1067b36
-  languageName: node
-  linkType: hard
-
-"stack-trace@npm:0.0.x":
-  version: 0.0.10
-  resolution: "stack-trace@npm:0.0.10"
-  checksum: 473036ad32f8c00e889613153d6454f9be0536d430eb2358ca51cad6b95cea08a3cc33cc0e34de66b0dad221582b08ed2e61ef8e13f4087ab690f388362d6610
   languageName: node
   linkType: hard
 
@@ -10084,13 +9992,6 @@ resolve@1.17.0:
     array-back: ^1.0.3
     typical: ^2.6.0
   checksum: ce41ef4100c9ac84630e78d1ca06706714587faf255e44296ace1fc7bf5b888c160b8c0229d31467252a3b2b57197965194391f6ee0c54f33e0b8e3af3a33a0c
-  languageName: node
-  linkType: hard
-
-"text-hex@npm:1.0.x":
-  version: 1.0.0
-  resolution: "text-hex@npm:1.0.0"
-  checksum: 1138f68adc97bf4381a302a24e2352f04992b7b1316c5003767e9b0d3367ffd0dc73d65001ea02b07cd0ecc2a9d186de0cf02f3c2d880b8a522d4ccb9342244a
   languageName: node
   linkType: hard
 
@@ -10758,35 +10659,6 @@ typescript@^3.9.3:
   dependencies:
     string-width: ^1.0.2 || 2 || 3 || 4
   checksum: d5fc37cd561f9daee3c80e03b92ed3e84d80dde3365a8767263d03dacfc8fa06b065ffe1df00d8c2a09f731482fcacae745abfbb478d4af36d0a891fad4834d3
-  languageName: node
-  linkType: hard
-
-"winston-transport@npm:^4.5.0":
-  version: 4.5.0
-  resolution: "winston-transport@npm:4.5.0"
-  dependencies:
-    logform: ^2.3.2
-    readable-stream: ^3.6.0
-    triple-beam: ^1.3.0
-  checksum: a56e5678a80b88a73e77ed998fc6e19d0db19c989a356b137ec236782f2bf58ae4511b11c29163f99391fa4dc12102c7bc5738dcb6543f28877fa2819adc3ee9
-  languageName: node
-  linkType: hard
-
-"winston@npm:^3.7.2":
-  version: 3.7.2
-  resolution: "winston@npm:3.7.2"
-  dependencies:
-    "@dabh/diagnostics": ^2.0.2
-    async: ^3.2.3
-    is-stream: ^2.0.0
-    logform: ^2.4.0
-    one-time: ^1.0.0
-    readable-stream: ^3.4.0
-    safe-stable-stringify: ^2.3.1
-    stack-trace: 0.0.x
-    triple-beam: ^1.3.0
-    winston-transport: ^4.5.0
-  checksum: f1f1a860d2fa228b50880b20aaa6cc121085907791fe0d814ff9c062640f6b65da321726322094e7667eb63088b3bb67e7b4e219d998f29efcc6f583185a1cd3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1743,7 +1743,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@mangrovedao/commonlib-js@workspace:*, @mangrovedao/commonlib-js@workspace:packages/commonlib.js":
+"@mangrovedao/commonlib-js@0.0.2, @mangrovedao/commonlib-js@workspace:*, @mangrovedao/commonlib-js@workspace:packages/commonlib.js":
   version: 0.0.0-use.local
   resolution: "@mangrovedao/commonlib-js@workspace:packages/commonlib.js"
   dependencies:
@@ -1884,6 +1884,7 @@ __metadata:
     "@ethersproject/experimental": ^5.6.1
     "@ethersproject/hardware-wallets": ^5.6.0
     "@ethersproject/providers": ^5.6.4
+    "@mangrovedao/commonlib-js": 0.0.2
     "@mangrovedao/hardhat-utils": "workspace:*"
     "@mangrovedao/mangrove-solidity": "workspace:*"
     "@nomiclabs/hardhat-ethers": ^2.0.5


### PR DESCRIPTION
Currently replaced Winston with loglevel. If fine, will 

- [ ] publish the commonlib package and 
- [ ] remove mangrove.js' logger.ts