### PR TITLE
feat(mangrove.js): Logging & force exit test suite

### DIFF
--- a/packages/hardhat-utils/mocha/hooks/integration-test-root-hooks.js
+++ b/packages/hardhat-utils/mocha/hooks/integration-test-root-hooks.js
@@ -89,6 +89,8 @@ exports.mochaHooks = {
   async afterAll() {
     if (server) {
       await server.close();
+      // we add the following logging to help debug test hangs
+      console.log("Hardhat server closed");
     }
   },
 };

--- a/packages/mangrove.js/package.json
+++ b/packages/mangrove.js/package.json
@@ -21,7 +21,7 @@
     "clean-typechain": "rimraf \"src/types/typechain/*\" || exit 0",
     "rollup": "rollup -c rollup.config.ts",
     "test-with-dependencies": "yarn workspaces foreach -vpiR --topological-dev --from $npm_package_name run test",
-    "test": "cross-env NODE_ENV=test NODE_OPTIONS=\"--max-old-space-size=4096\" nyc --reporter=lcov mocha --config test/mocha/config/integration-tests.json",
+    "test": "cross-env NODE_ENV=test NODE_OPTIONS=\"--max-old-space-size=4096\" nyc --reporter=lcov mocha --config test/mocha/config/integration-tests.json --exit",
     "typechain": "yarn run clean-typechain && npx typechain --target=ethers-v5 --out-dir=src/types/typechain \"src/abis/*.json\"",
     "doc": "cd src && yarn typedoc --options ../typedoc.json index.ts"
   },


### PR DESCRIPTION
We want to mitigate and debug flaky test hangs in the mangrove.js suite. We start by adding a log message, when we've closed the hardhat server (to help rule out that cause out), and we force mocha to exit after tests are done. We do the latter knowing that having these points to mocha waiting a hanging connection etc somewhere. However, since the future of some of the mangrove.js tests are unsure, we choose this route to help getting more stable test runs.