### PR TITLE
fix: Use the right working directory when building the faucet package

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -157,6 +157,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    env:
+      working-directory: packages/faucet
+
     defaults:
       run:
         working-directory: ${{env.working-directory}}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,7 +18,6 @@ concurrency:
 
 env:
   NODE_ENV: test
-  working-directory: packages/mangrove-solidity
   # Ternary-esque expression hack: The first line is the condition,
   # the 2nd line is the value if `true`, the 3rd line is the value if `false`.
   GIT_REF_TO_TEST: >
@@ -77,7 +76,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: packages/commonlib.js
+        working-directory: ${{env.working-directory}}
 
     strategy:
       matrix:
@@ -244,6 +243,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    env:
+      working-directory: packages/mangrove-solidity
+
     defaults:
       run:
         working-directory: ${{env.working-directory}}
@@ -358,6 +360,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    env:
+      working-directory: packages/mangrove-solidity
+
     defaults:
       run:
         working-directory: ${{env.working-directory}}    
@@ -419,7 +424,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: packages/hardhat-utils
+        working-directory: ${{env.working-directory}}
 
     strategy:
       matrix:
@@ -517,7 +522,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: packages/mangrove.js
+        working-directory: ${{env.working-directory}}
 
     strategy:
       matrix:
@@ -645,7 +650,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: packages/mangrove.js
+        working-directory: ${{env.working-directory}}
 
     steps:
 
@@ -725,7 +730,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: packages/bot-cleaning
+        working-directory: ${{env.working-directory}}
 
     strategy:
       matrix:
@@ -841,7 +846,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: packages/bot-updategas
+        working-directory: ${{env.working-directory}}
 
     strategy:
       matrix:
@@ -957,7 +962,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: packages/bot-maker-noise
+        working-directory: ${{env.working-directory}}
 
     strategy:
       matrix:
@@ -1073,7 +1078,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: packages/bot-taker-greedy
+        working-directory: ${{env.working-directory}}
 
     strategy:
       matrix:
@@ -1189,7 +1194,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: packages/bot-template
+        working-directory: ${{env.working-directory}}
 
     strategy:
       matrix:

--- a/packages/faucet/hardhat.config.js
+++ b/packages/faucet/hardhat.config.js
@@ -60,4 +60,14 @@ module.exports = {
       default: 4,
     },
   },
+  mocha: {
+    // Use multiple reporters to output to both stdout and a json file
+    reporter: "mocha-multi-reporters",
+    reporterOptions: {
+      reporterEnabled: "spec, @espendk/json-file-reporter",
+      espendkJsonFileReporterReporterOptions: {
+        output: "solidity-mocha-test-report.json",
+      },
+    },
+  },
 };


### PR DESCRIPTION
Also,  change the workflow to consistently handle package working directories:

For historical reasons, the default working directory was `packages/mangrove-solidity` and the jobs for that package therefore didn't specify a working package.

However, this adds unnecessary complexity, resulting in issues like the one fixed in @556e3af.

This commit therefore removes the default working directory and makes it explicit for the `mangrove-solidity` jobs.