### PR TITLE
build: Add a Heroku-specific build path that avoids Foundry

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
         ]
     },
     "scripts": {
-        "postinstall": "husky install",
-        "heroku-postbuild": "pinst --disable && yarn build",
+        "_postinstall": "husky install",
+        "heroku-postbuild": "pinst --disable && yarn heroku-build",
+        "heroku-build": "yarn install && yarn workspaces foreach --topological-dev run heroku-build-this-package",
         "heroku-cleanup": "pinst --enable",
         "build": "yarn install && yarn workspaces foreach --topological-dev run build-this-package",
         "clean": "yarn workspaces foreach --topological-dev run clean-this-package",

--- a/packages/bot-cleaning/package.json
+++ b/packages/bot-cleaning/package.json
@@ -15,6 +15,7 @@
     "prepack": "yarn build",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "build-this-package": "tsc && yarn run write-env-info-file",
+    "heroku-build-this-package": "yarn run build-this-package",
     "build": "yarn install && yarn workspaces foreach -vpiR --topological-dev --from $npm_package_name run build-this-package",
     "clean-this-package": "rimraf build",
     "clean": "yarn workspaces foreach -vpiR --topological-dev --from $npm_package_name run clean-this-package",

--- a/packages/bot-maker-noise/package.json
+++ b/packages/bot-maker-noise/package.json
@@ -15,6 +15,7 @@
     "prepack": "yarn build",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "build-this-package": "tsc && yarn run write-env-info-file",
+    "heroku-build-this-package": "yarn run build-this-package",
     "build": "yarn install && yarn workspaces foreach -vpiR --topological-dev --from $npm_package_name run build-this-package",
     "clean-this-package": "rimraf build",
     "clean": "yarn workspaces foreach -vpiR --topological-dev --from $npm_package_name run clean-this-package",

--- a/packages/bot-taker-greedy/package.json
+++ b/packages/bot-taker-greedy/package.json
@@ -15,6 +15,7 @@
     "prepack": "yarn build",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "build-this-package": "tsc && yarn run write-env-info-file",
+    "heroku-build-this-package": "yarn run build-this-package",
     "build": "yarn install && yarn workspaces foreach -vpiR --topological-dev --from $npm_package_name run build-this-package",
     "clean-this-package": "rimraf build",
     "clean": "yarn workspaces foreach -vpiR --topological-dev --from $npm_package_name run clean-this-package",

--- a/packages/bot-template/package.json
+++ b/packages/bot-template/package.json
@@ -15,6 +15,7 @@
     "prepack": "yarn build",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "build-this-package": "tsc && yarn run write-env-info-file",
+    "heroku-build-this-package": "yarn run build-this-package",
     "build": "yarn install && yarn workspaces foreach -vpiR --topological-dev --from $npm_package_name run build-this-package",
     "clean-this-package": "rimraf build",
     "clean": "yarn workspaces foreach -vpiR --topological-dev --from $npm_package_name run clean-this-package",

--- a/packages/bot-updategas/package.json
+++ b/packages/bot-updategas/package.json
@@ -15,6 +15,7 @@
     "prepack": "yarn build",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "build-this-package": "tsc && yarn run write-env-info-file",
+    "heroku-build-this-package": "yarn run build-this-package",
     "build": "yarn install && yarn workspaces foreach -vpiR --topological-dev --from $npm_package_name run build-this-package",
     "clean-this-package": "rimraf build",
     "clean": "yarn workspaces foreach -vpiR --topological-dev --from $npm_package_name run clean-this-package",

--- a/packages/commonlib.js/package.json
+++ b/packages/commonlib.js/package.json
@@ -15,6 +15,7 @@
     "prepack": "yarn build",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "build-this-package": "tsc",
+    "heroku-build-this-package": "yarn run build-this-package",
     "build": "yarn install && yarn workspaces foreach -vpiR --topological-dev --from $npm_package_name run build-this-package",
     "clean-this-package": "rimraf dist",
     "clean": "yarn workspaces foreach -vpiR --topological-dev --from $npm_package_name run clean-this-package",

--- a/packages/faucet/package.json
+++ b/packages/faucet/package.json
@@ -7,6 +7,7 @@
     "precommit": "lint-staged",
     "prepack": "yarn build",
     "build-this-package": "hardhat compile",
+    "heroku-build-this-package": "yarn run build-this-package",
     "build": "yarn install && yarn workspaces foreach -vpiR --topological-dev --from $npm_package_name run build-this-package",
     "clean-this-package": "rimraf build cache dist",
     "clean": "yarn workspaces foreach -vpiR --topological-dev --from $npm_package_name run clean-this-package",

--- a/packages/hardhat-utils/package.json
+++ b/packages/hardhat-utils/package.json
@@ -10,6 +10,7 @@
     "prepack": "build",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "build-this-package": "",
+    "heroku-build-this-package": "yarn run build-this-package",
     "build": "yarn install && yarn workspaces foreach -vpiR --topological-dev --from $npm_package_name run build-this-package",
     "clean-this-package": "",
     "clean": "yarn workspaces foreach -vpiR --topological-dev --from $npm_package_name run clean-this-package",

--- a/packages/mangrove-solidity/package.json
+++ b/packages/mangrove-solidity/package.json
@@ -7,7 +7,7 @@
     "precommit": "lint-staged",
     "prepack": "yarn build",
     "build-this-package": "hardhat compile && forge build && yarn run copy-distribution-assets",
-    "heroku-build-this-package": "hardhat compile && yarn run copy-distribution-assets",
+    "heroku-build-this-package": "echo No build of contracts needed for Heroku as ABIs are committed to mangrove.js",
     "build": "yarn install && yarn workspaces foreach -vpiR --topological-dev --from $npm_package_name run build-this-package",
     "copy-distribution-assets": "node copyDistributionAssets.js",
     "clean-this-package": "rimraf deployments/hardhat deployments/localhost artifacts cache dist exported-abis foundry_out",

--- a/packages/mangrove-solidity/package.json
+++ b/packages/mangrove-solidity/package.json
@@ -7,6 +7,7 @@
     "precommit": "lint-staged",
     "prepack": "yarn build",
     "build-this-package": "hardhat compile && forge build && yarn run copy-distribution-assets",
+    "heroku-build-this-package": "hardhat compile && yarn run copy-distribution-assets",
     "build": "yarn install && yarn workspaces foreach -vpiR --topological-dev --from $npm_package_name run build-this-package",
     "copy-distribution-assets": "node copyDistributionAssets.js",
     "clean-this-package": "rimraf deployments/hardhat deployments/localhost artifacts cache dist exported-abis foundry_out",

--- a/packages/mangrove.js/package.json
+++ b/packages/mangrove.js/package.json
@@ -11,6 +11,7 @@
     "prepack": "yarn run build",
     "lint": "npx eslint ./src/*.ts",
     "build-this-package": "yarn run get-mangrove-abis && yarn run typechain && yarn run lint && tsc --build src && yarn run make-cli-executable && yarn run write-test-deployment-file && yarn run rollup",
+    "heroku-build-this-package": "yarn run build-this-package",
     "build": "yarn install && yarn workspaces foreach -vpiR --topological-dev --from $npm_package_name run build-this-package",
     "check-mangrove-abis": "ts-node warnIfDifferent.ts -- node_modules/@mangrovedao/mangrove-solidity/dist/mangrove-abis src/abis \"Warning! Mangrove ABIs in src/abis do not match ABIs in mangrove-solidity\"",
     "get-mangrove-abis": "cp node_modules/@mangrovedao/mangrove-solidity/dist/mangrove-abis/*.json ./src/abis/",

--- a/packages/mangrove.js/package.json
+++ b/packages/mangrove.js/package.json
@@ -11,7 +11,7 @@
     "prepack": "yarn run build",
     "lint": "npx eslint ./src/*.ts",
     "build-this-package": "yarn run get-mangrove-abis && yarn run typechain && yarn run lint && tsc --build src && yarn run make-cli-executable && yarn run write-test-deployment-file && yarn run rollup",
-    "heroku-build-this-package": "yarn run typechain && yarn run lint && tsc --build src && yarn run make-cli-executable && yarn run write-test-deployment-file && yarn run rollup",
+    "heroku-build-this-package": "yarn run typechain && yarn run lint && tsc --build src && yarn run rollup",
     "build": "yarn install && yarn workspaces foreach -vpiR --topological-dev --from $npm_package_name run build-this-package",
     "check-mangrove-abis": "ts-node warnIfDifferent.ts -- node_modules/@mangrovedao/mangrove-solidity/dist/mangrove-abis src/abis \"Warning! Mangrove ABIs in src/abis do not match ABIs in mangrove-solidity\"",
     "get-mangrove-abis": "cp node_modules/@mangrovedao/mangrove-solidity/dist/mangrove-abis/*.json ./src/abis/",

--- a/packages/mangrove.js/package.json
+++ b/packages/mangrove.js/package.json
@@ -11,7 +11,7 @@
     "prepack": "yarn run build",
     "lint": "npx eslint ./src/*.ts",
     "build-this-package": "yarn run get-mangrove-abis && yarn run typechain && yarn run lint && tsc --build src && yarn run make-cli-executable && yarn run write-test-deployment-file && yarn run rollup",
-    "heroku-build-this-package": "yarn run build-this-package",
+    "heroku-build-this-package": "yarn run typechain && yarn run lint && tsc --build src && yarn run make-cli-executable && yarn run write-test-deployment-file && yarn run rollup",
     "build": "yarn install && yarn workspaces foreach -vpiR --topological-dev --from $npm_package_name run build-this-package",
     "check-mangrove-abis": "ts-node warnIfDifferent.ts -- node_modules/@mangrovedao/mangrove-solidity/dist/mangrove-abis src/abis \"Warning! Mangrove ABIs in src/abis do not match ABIs in mangrove-solidity\"",
     "get-mangrove-abis": "cp node_modules/@mangrovedao/mangrove-solidity/dist/mangrove-abis/*.json ./src/abis/",


### PR DESCRIPTION
Temp workaround for the broken build on Heroku, see #561.