### PR TITLE
feat(test): save/restore pranks, apply to cash()

### DIFF
--- a/packages/mangrove-solidity/contracts/test/lib/MangroveTest.sol
+++ b/packages/mangrove-solidity/contracts/test/lib/MangroveTest.sol
@@ -361,15 +361,16 @@ contract MangroveTest is Test2, HasMgvEvents {
 
   /* **** Token conversion */
   /* return underlying amount with correct number of decimals */
-  function cash(TestToken t, uint amount) public returns (uint) {
-    // don't use an ongoing vm.prank here
-    uint decimals = stdstore.target(address(t)).sig("__decimals()").read_uint();
+  function cash(IERC20 t, uint amount) public returns (uint) {
+    savePrank();
+    uint decimals = t.decimals();
+    restorePrank();
     return amount * 10**decimals;
   }
 
   /* return underlying amount divided by 10**power */
   function cash(
-    TestToken t,
+    IERC20 t,
     uint amount,
     uint power
   ) public returns (uint) {

--- a/packages/mangrove-solidity/contracts/test/strategies/Guaave.t.sol
+++ b/packages/mangrove-solidity/contracts/test/strategies/Guaave.t.sol
@@ -37,8 +37,8 @@ contract GuaaveTest is MangroveTest {
 
     maker = freshAddress("maker");
     taker = freshAddress("taker");
-    deal($(weth), taker, 50 ether + weth.balanceOf(taker), true);
-    deal($(usdc), taker, 100_000 * 10**6 + usdc.balanceOf(taker), true);
+    deal($(weth), taker, cash(weth, 50) + weth.balanceOf(taker), true);
+    deal($(usdc), taker, cash(usdc, 100_000) + usdc.balanceOf(taker), true);
 
     vm.startPrank(maker);
     mgo = new Mango({
@@ -93,7 +93,7 @@ contract GuaaveTest is MangroveTest {
     vm.stopPrank();
     mgv.fund{value: prov * (NSLOTS * 2)}($(mgo));
     vm.startPrank(maker);
-    deal($(weth), $(mgo), 17 ether + weth.balanceOf($(mgo)), true);
+    deal($(weth), $(mgo), cash(weth, 17) + weth.balanceOf($(mgo)), true);
 
     IERC20[] memory tokens = new IERC20[](2);
     tokens[0] = weth;

--- a/packages/mangrove-solidity/contracts/test/toy_strategies/AaveLender.t.sol
+++ b/packages/mangrove-solidity/contracts/test/toy_strategies/AaveLender.t.sol
@@ -56,8 +56,8 @@ contract AaveLenderTest is AaveV3ModuleTest {
     weth.approve($(mgv), type(uint).max);
     dai.approve($(mgv), type(uint).max);
 
-    deal($(weth), $(this), 10 ether);
-    deal($(dai), $(this), 10_000 ether);
+    deal($(weth), $(this), cash(weth, 10));
+    deal($(dai), $(this), cash(dai, 10_000));
   }
 
   function test_run() public {


### PR DESCRIPTION
new `savePrank/restorePrank` test methods can save the current prank and call e.g. view functions without disrupting the current pranking situation.

Immediately useful with `cash`, which previously relied on [stdStorage](https://github.com/foundry-rs/forge-std/blob/master/src/Test.sol) and only worked on `TestToken`s, and can now just do

```solidity
savePrank();
uint decimals = t.decimals();
restorePrank();
```