### PR TITLE
fix(build)!: Change mangrove-solidity local tests to use .env.local.test

### DIFF
--- a/packages/mangrove-solidity/package.json
+++ b/packages/mangrove-solidity/package.json
@@ -17,8 +17,8 @@
     "test-with-dependencies": "yarn workspaces foreach -vpiR --topological-dev --from $npm_package_name run test",
     "test": "npm-run-all \"test:*\"",
     "test:solidity": "npm-run-all --continue-on-error \"test:solidity:*\"",
-    "test:solidity:local": "bash -c 'source .env; forge test -vvv --no-match-contract \\'^(Guaave|AaveLender|OfferProxy|OasisLike)Test$\\''",
-    "test:solidity:polygon": "bash -c 'source .env; forge test -vvv --fork-url $POLYGON_NODE_URL --fork-block-number 26416000 --match-contract \\'^(Guaave|AaveLender|OfferProxy|OasisLike)Test$\\''"
+    "test:solidity:local": "dotenv -e .env.test.local -- bash -c 'forge test -vvv --no-match-contract \\'^(Guaave|AaveLender|OfferProxy|OasisLike)Test$\\''",
+    "test:solidity:polygon": "dotenv -e .env.test.local -- bash -c 'forge test -vvv --fork-url $POLYGON_NODE_URL --fork-block-number 26416000 --match-contract \\'^(Guaave|AaveLender|OfferProxy|OasisLike)Test$\\''"
   },
   "lint-staged": {
     "*.{js,css,md,sol,json}": "prettier --write --ignore-unknown"
@@ -34,6 +34,7 @@
     "chai-events": "^0.0.3",
     "config": "^3.3.7",
     "cross-env": "^7.0.3",
+    "dotenv-cli": "^6.0.0",
     "dotenv-flow": "^3.2.0",
     "ethers": "^5.6.4",
     "fs": "^0.0.1-security",

--- a/packages/mangrove.js/package.json
+++ b/packages/mangrove.js/package.json
@@ -10,7 +10,7 @@
     "precommit": "lint-staged",
     "prepack": "yarn run build",
     "lint": "npx eslint ./src/*.ts",
-    "build-this-package": "yarn run get-mangrove-abis && yarn run typechain && yarn run lint && tsc --build src && yarn run make-cli-executable && yarn run write-test-deployment-file && yarn run rollup",
+    "build-this-package": "yarn run get-mangrove-abis && yarn run typechain && yarn run lint && tsc --build src && yarn run make-cli-executable && cross-env NODE_OPTIONS=--max-old-space-size=8192 yarn run write-test-deployment-file && yarn run rollup",
     "heroku-build-this-package": "yarn run typechain && yarn run lint && tsc --build src && yarn run rollup",
     "build": "yarn install && yarn workspaces foreach -vpiR --topological-dev --from $npm_package_name run build-this-package",
     "check-mangrove-abis": "ts-node warnIfDifferent.ts -- node_modules/@mangrovedao/mangrove-solidity/dist/mangrove-abis src/abis \"Warning! Mangrove ABIs in src/abis do not match ABIs in mangrove-solidity\"",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2031,6 +2031,7 @@ __metadata:
     chai-events: ^0.0.3
     config: ^3.3.7
     cross-env: ^7.0.3
+    dotenv-cli: ^6.0.0
     dotenv-flow: ^3.2.0
     ethers: ^5.6.4
     fs: ^0.0.1-security
@@ -4456,12 +4457,40 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dotenv-cli@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "dotenv-cli@npm:6.0.0"
+  dependencies:
+    cross-spawn: ^7.0.3
+    dotenv: ^16.0.0
+    dotenv-expand: ^8.0.1
+    minimist: ^1.2.5
+  bin:
+    dotenv: cli.js
+  checksum: 3db5a363eedd24d428001a956d9b8c72094983bfe0e0e722cda7803b614daf85dde9c9beb5d9fa28a139a5c594533ecd8f9d8430a90c244175e81c9a40abc5b1
+  languageName: node
+  linkType: hard
+
+"dotenv-expand@npm:^8.0.1":
+  version: 8.0.3
+  resolution: "dotenv-expand@npm:8.0.3"
+  checksum: 128ce90ac825b543de3ece0154a51b056ab0dc36bb26d97a68cd0b8707327ecd3c182fb6ac63b26a0fcdfa85064419906a1065cb634f1f9dc08ad311375f1fc0
+  languageName: node
+  linkType: hard
+
 "dotenv-flow@npm:^3.2.0":
   version: 3.2.0
   resolution: "dotenv-flow@npm:3.2.0"
   dependencies:
     dotenv: ^8.0.0
   checksum: 8e34ea8f5cb216acb0f9cc602752dceef6e1c0b52c39045d6b92fadbefcbfecaf0cc868d3e115c9764860293d62d0bb31d46cfa41d29cb9fc7039797e20de03e
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^16.0.0":
+  version: 16.0.1
+  resolution: "dotenv@npm:16.0.1"
+  checksum: f459ffce07b977b7f15d8cc4ee69cdff77d4dd8c5dc8c85d2d485ee84655352c2415f9dd09d42b5b5985ced3be186130871b34e2f3e2569ebc72fbc2e8096792
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Also upped the available memory for JavaScript heap when building mangrove.js.

Consequential changes from https://github.com/mangrovedao/mangrove/pull/541 related to the epic https://github.com/mangrovedao/mangrove-tasks/issues/129
