### PR TITLE
fix(foundry): Fixup foundry.toml format

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,12 +1,12 @@
 # Note: remember to `git submodule update --recursive` to pull in dependencies
-[default]
+[profile.default]
 src='packages/mangrove-solidity/contracts'
 test='packages/mangrove-solidity/foundry_test'
 out='packages/mangrove-solidity/foundry_out'
 libs=['packages/mangrove-solidity/foundry_lib']
 cache_path='packages/mangrove-solidity/foundry_cache'
 solc_version="0.8.14"
-[polygon]
+[profile.polygon]
 eth_rpc_url="https://polygon-rpc.com"
 fork_block_number=26416000
 # The remappings are in remappings.txt so vscode solidity ext. can read them


### PR DESCRIPTION
Remove these warnings

```
warning: Unknown section [default] found in ../../foundry.toml. This notation for profiles has been deprecated and may result in the profile not being registered in future versions. Please use [profile.default] instead or run `forge config --fix`.
warning: Unknown section [polygon] found in ../../foundry.toml. This notation for profiles has been deprecated and may result in the profile not being registered in future versions. Please use [profile.polygon] instead or run `forge config --fix`.
```