### PR TITLE
fix(test): Don't override NODE_OPTIONS's vscode bootloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ This can also be done from a specific package in `./packages/<somePackage>` and 
 If you encounter issues with JavaScript memory consumption, then try increasing the max available space for heap, and try again:
 
 ```shell
-$ export NODE_OPTIONS=--max_old_space_size=4096
+$ export NODE_OPTIONS="$NODE_OPTIONS --max_old_space_size=4096"
 $ yarn build
 ```
 

--- a/packages/mangrove.js/package.json
+++ b/packages/mangrove.js/package.json
@@ -22,7 +22,7 @@
     "clean-typechain": "rimraf \"src/types/typechain/*\" || exit 0",
     "rollup": "rollup -c rollup.config.ts",
     "test-with-dependencies": "yarn workspaces foreach -vpiR --topological-dev --from $npm_package_name run test",
-    "test": "cross-env NODE_ENV=test NODE_OPTIONS=\"--max-old-space-size=8192\" nyc --reporter=lcov mocha --config test/mocha/config/integration-tests.json --exit",
+    "test": "cross-env NODE_ENV=test nyc --max-old-space-size=8192 --reporter=lcov mocha --config test/mocha/config/integration-tests.json --exit",
     "typechain": "yarn run clean-typechain && npx typechain --target=ethers-v5 --out-dir=src/types/typechain \"src/abis/*.json\"",
     "doc": "cd src && yarn typedoc --options ../typedoc.json index.ts"
   },

--- a/packages/mangrove.js/package.json
+++ b/packages/mangrove.js/package.json
@@ -22,7 +22,7 @@
     "clean-typechain": "rimraf \"src/types/typechain/*\" || exit 0",
     "rollup": "rollup -c rollup.config.ts",
     "test-with-dependencies": "yarn workspaces foreach -vpiR --topological-dev --from $npm_package_name run test",
-    "test": "cross-env NODE_ENV=test nyc --max-old-space-size=8192 --reporter=lcov mocha --config test/mocha/config/integration-tests.json --exit",
+    "test": "cross-env NODE_ENV=test nyc --reporter=lcov mocha --max-old-space-size=8192 --config test/mocha/config/integration-tests.json --exit",
     "typechain": "yarn run clean-typechain && npx typechain --target=ethers-v5 --out-dir=src/types/typechain \"src/abis/*.json\"",
     "doc": "cd src && yarn typedoc --options ../typedoc.json index.ts"
   },


### PR DESCRIPTION
VSCode appends a --require /very/long/path/extensions/ms-vscode.js-debug/src/bootloader.bundle.js to NODE_OPTIONS which I accidentally overrode when increasing JS heap memory. Now we no longer override but use cmd line options instead.