### PR TITLE
Feature/unified deploy

### DIFF
--- a/packages/mangrove-solidity/script/MangroveJs.s.sol
+++ b/packages/mangrove-solidity/script/MangroveJs.s.sol
@@ -53,7 +53,7 @@ contract MangroveJsDeploy is Deployer {
       symbol: "TokenA",
       _decimals: 18
     });
-    ens.set("TokenA", address(tokenA), true);
+    register("TokenA", address(tokenA), true);
 
     vm.broadcast();
     tokenB = new TestToken({
@@ -62,7 +62,7 @@ contract MangroveJsDeploy is Deployer {
       symbol: "TokenB",
       _decimals: 18
     });
-    ens.set("TokenB", address(tokenB), true);
+    register("TokenB", address(tokenB), true);
 
     vm.broadcast();
     dai = new TestToken({
@@ -71,7 +71,7 @@ contract MangroveJsDeploy is Deployer {
       symbol: "DAI",
       _decimals: 18
     });
-    ens.set("DAI", address(dai), true);
+    register("DAI", address(dai), true);
 
     vm.broadcast();
     usdc = new TestToken({
@@ -80,7 +80,7 @@ contract MangroveJsDeploy is Deployer {
       symbol: "USDC",
       _decimals: 6
     });
-    ens.set("USDC", address(usdc), true);
+    register("USDC", address(usdc), true);
 
     vm.broadcast();
     weth = new TestToken({
@@ -89,7 +89,7 @@ contract MangroveJsDeploy is Deployer {
       symbol: "WETH",
       _decimals: 18
     });
-    ens.set("WETH", address(weth), true);
+    register("WETH", address(weth), true);
 
     vm.broadcast();
     simpleTestMaker = new SimpleTestMaker({
@@ -97,10 +97,10 @@ contract MangroveJsDeploy is Deployer {
       base: tokenA,
       quote: tokenB
     });
-    ens.set("SimpleTestMaker", address(simpleTestMaker));
+    register("SimpleTestMaker", address(simpleTestMaker));
 
     vm.broadcast();
     mgo = new MangroveOrder({_MGV: IMangrove(payable(mgv)), deployer: chief});
-    ens.set("MangroveOrder", address(mgo));
+    register("MangroveOrder", address(mgo));
   }
 }

--- a/packages/mangrove-solidity/script/lib/Deployer.sol
+++ b/packages/mangrove-solidity/script/lib/Deployer.sol
@@ -3,9 +3,10 @@ pragma solidity ^0.8.13;
 import {Script, console} from "forge-std/Script.sol";
 import {ToyENS} from "./ToyENS.sol";
 
-/* Outputs deployments as follows:
-
-   To a toy ENS instance. Useful for testing when the server & testing script
+/* Writes deployments in 2 ways:
+   1. In a deployment file. Easier to write one directly that to parse&transform
+   foundry broadcast log files.
+   2. In a toy ENS instance. Useful for testing when the server & testing script
    are both spawned in-process. Holds additional info on the contracts (whether
    it's a token). In the future, could be either removed (in favor of a
    file-based solution), or expanded (if an onchain addressProvider appears).
@@ -20,6 +21,8 @@ import {ToyENS} from "./ToyENS.sol";
 abstract contract Deployer is Script {
   ToyENS ens; // singleton local ens instance
   ToyENS remoteEns; // out-of-band agreed upon toy ens address
+  mapping(uint => string) chainkeys; // out-of-band agreed upon chain names
+  string filePrefix; // deployment folder to write to
 
   constructor() {
     // enforce singleton ENS, so all deploys can be collected in outputDeployment
@@ -28,9 +31,38 @@ abstract contract Deployer is Script {
     ens = ToyENS(address(bytes20(hex"decaf1")));
     remoteEns = ToyENS(address(bytes20(hex"decaf0")));
 
+    chainkeys[80001] = "maticmum";
+    chainkeys[127] = "polygon";
+    chainkeys[31337] = "local"; // useful for debugging
+
+    filePrefix = "packages/mangrove-solidity/deployments/";
+
     if (address(ens).code.length == 0) {
       vm.etch(address(ens), address(new ToyENS()).code);
     }
+  }
+
+  function file(bool withTimestamp) internal view returns (string memory) {
+    return
+      string.concat(
+        filePrefix,
+        chainkeys[block.chainid],
+        "/",
+        withTimestamp ? vm.toString(block.timestamp) : "latest",
+        ".json"
+      );
+  }
+
+  function register(string memory name, address addr) internal {
+    register(name, addr, false);
+  }
+
+  function register(
+    string memory name,
+    address addr,
+    bool isToken
+  ) internal {
+    ens.set(name, addr, isToken);
   }
 
   function outputDeployment() internal {
@@ -42,5 +74,32 @@ abstract contract Deployer is Script {
       vm.broadcast();
       remoteEns.set(names, addrs, isToken);
     }
+
+    // known chain, write deployment file
+    if (bytes(chainkeys[block.chainid]).length != 0) {
+      vm.writeFile(file(false), ""); // clear, script seems to run 6 times
+      vm.writeFile(file(true), ""); // clear, script seems to run 6 times
+      write("{");
+      for (uint i = 0; i < names.length; i++) {
+        string memory end = i + 1 == names.length ? "" : ",";
+        write(
+          string.concat(
+            '  "',
+            names[i],
+            '": "',
+            vm.toString(addrs[i]),
+            '"',
+            end
+          )
+        );
+      }
+      write("}");
+    }
+  }
+
+  // write both in timestamped and in 'latest'
+  function write(string memory s) internal {
+    vm.writeLine(file(true), s);
+    vm.writeLine(file(false), s);
   }
 }

--- a/packages/mangrove-solidity/script/lib/MangroveDeployer.sol
+++ b/packages/mangrove-solidity/script/lib/MangroveDeployer.sol
@@ -30,25 +30,25 @@ contract MangroveDeployer is Deployer {
   ) public {
     vm.broadcast();
     mgv = new Mangrove({governance: chief, gasprice: gasprice, gasmax: gasmax});
-    ens.set("Mangrove", address(mgv));
+    register("Mangrove", address(mgv));
 
     vm.broadcast();
     reader = new MgvReader({_mgv: payable(mgv)});
-    ens.set("MgvReader", address(reader));
+    register("MgvReader", address(reader));
 
     vm.broadcast();
     cleaner = new MgvCleaner({_MGV: address(mgv)});
-    ens.set("MgvCleaner", address(cleaner));
+    register("MgvCleaner", address(cleaner));
 
     vm.broadcast();
     oracle = new MgvOracle({_governance: chief, _initialMutator: chief});
-    ens.set("MgvOracle", address(oracle));
+    register("MgvOracle", address(oracle));
 
     vm.broadcast();
     mgoe = new MangroveOrderEnriched({
       _MGV: IMangrove(payable(mgv)),
       deployer: chief
     });
-    ens.set("MangroveOrderEnriched", address(mgoe));
+    register("MangroveOrderEnriched", address(mgoe));
   }
 }


### PR DESCRIPTION
Would like to know your opinion on this change to deploys management.

Current strategy under foundry is to parse "foundry broadcast logs". They are files that summarize an onchain deployment.

Pros:
* Managed by foundry
* Separate unsent txs from mined txs

Cons:
* Too generic to e.g. easily parse a deploy that creates >1 instance of the same contract
* Not trivial to parse

Proposed strategy here is to write a deployment file as part of the deployment.
Pros:
* Can write arbitrary data to the deployment file, give special names to deployed contracts
* End result is immediately readable by e.g. mangrove.js

Cons:
* Ad-hoc, does not reuse existing foundry infrastructure.
* File is generated when the script is executed but not after the transactions have been mined, so could create a discrepancy between what's in the deployment files and what's actually onchain.

P.S. Ignore the renamed files, changes start here: https://github.com/mangrovedao/mangrove/compare/feature/anviltests...feature/unifiedDeploy#diff-0e0a0b427ef3af9b716c4c35566e7a95310881d5018b28398a5d30c539528d0c