### PR TITLE
feat(bundling): Make esbuild use TypeScript when bundling

### DIFF
--- a/packages/commonlib.js/src/index.ts
+++ b/packages/commonlib.js/src/index.ts
@@ -5,7 +5,7 @@ import { sleep } from "./promiseUtil";
 
 export {
   ErrorWithData,
-  CommonLogger,
+  type CommonLogger,
   createLogger,
   createConsoleLogger,
   logdataLimiter,

--- a/packages/commonlib.js/tsconfig.json
+++ b/packages/commonlib.js/tsconfig.json
@@ -3,6 +3,7 @@
     "module": "CommonJS",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
+    "emitDecoratorMetadata": false, // this is the default. Calling it out since esbuild does not support it.
     "target": "es2020",
     "strict": true,
     "noImplicitAny": true,
@@ -18,7 +19,8 @@
     },
     "typeRoots": ["./types", "./node_modules/@types"],
     "composite": true,
-    "rootDir": "src/"
+    "rootDir": "src/",
+    "isolatedModules": true
   },
   "include": ["src/**/*.ts"]
 }

--- a/packages/mangrove.js/esbuild.mjs
+++ b/packages/mangrove.js/esbuild.mjs
@@ -5,20 +5,20 @@ import { build } from "esbuild";
 import resolve from "esbuild-plugin-resolve";
 
 build({
-  entryPoints: ["./dist/nodejs/index.js"],
+  entryPoints: ["./src/index.ts"],
   bundle: true,
   minify: true,
   outfile: BrowserBuildPath,
   platform: "browser",
   format: "iife",
-  globalName: "_Mangrove",
+  globalName: "Mangrove",
   footer: {
-    js: "module.exports = _Mangrove; module.exports.default = _Mangrove;",
+    js: "module.exports = Mangrove;",
   },
   plugins: [
     resolve({
-      "@mangrovedao/commonlib.js": "../../../shims/commonlib.ts",
-      "./util/readJsonWallet": "../../shims/readJsonWallet.ts",
+      "@mangrovedao/commonlib.js": "../../shims/commonlib.ts",
+      "./util/readJsonWallet": "../shims/readJsonWallet.ts",
     }),
   ],
 });

--- a/packages/mangrove.js/esbuild.mjs
+++ b/packages/mangrove.js/esbuild.mjs
@@ -10,7 +10,11 @@ build({
   minify: true,
   outfile: BrowserBuildPath,
   platform: "browser",
-  format: "cjs",
+  format: "iife",
+  globalName: "_Mangrove",
+  footer: {
+    js: "module.exports = _Mangrove; module.exports.default = _Mangrove;",
+  },
   plugins: [
     resolve({
       "@mangrovedao/commonlib.js": "../../../shims/commonlib.ts",

--- a/packages/mangrove.js/package.json
+++ b/packages/mangrove.js/package.json
@@ -11,7 +11,7 @@
     "precommit": "lint-staged",
     "prepack": "yarn run build",
     "lint": "npx eslint ./src/*.ts",
-    "build-this-package": "npm-run-all -pn --aggregate-output get-mangrove-abis get-mangrove-addresses && npm-run-all -pn --aggregate-output typechain lint && yarn tscbuild && yarn esbuild && yarn make-cli-executable",
+    "build-this-package": "npm-run-all -pn --aggregate-output get-mangrove-abis get-mangrove-addresses && npm-run-all -pn --aggregate-output typechain lint && npm-run-all -pn --aggregate-output tscbuild esbuild && yarn make-cli-executable",
     "heroku-build-this-package": "yarn typechain && yarn lint && yarn tscbuild && yarn esbuild",
     "build": "yarn install && yarn workspaces foreach -vpiR --topological-dev --from $npm_package_name run build-this-package",
     "check-mangrove-abis": "ts-node warnIfDifferent.ts -- ../../node_modules/@mangrovedao/mangrove-solidity/dist/mangrove-abis src/abis \"Warning! Mangrove ABIs in src/abis do not match ABIs in mangrove-solidity\"",

--- a/packages/mangrove.js/tsconfig.json
+++ b/packages/mangrove.js/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["ES2020", "dom"],
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
+    "emitDecoratorMetadata": false, // this is the default. Calling it out since esbuild does not support it.
     "target": "es2020",
     //"strict": true,
     //"noImplicitAny": true,
@@ -20,7 +21,8 @@
       "*": ["node_modules/*"]
     },
     "composite": true,
-    "rootDir": "src/"
+    "rootDir": "src/",
+    "isolatedModules": true
   },
   "include": ["src/**/*.ts", "src/**/*.d.ts", "src/constants/*.json"],
   "references": [


### PR DESCRIPTION
Follow-up to https://github.com/mangrovedao/mangrove/pull/657

* Switch to iife bundling for esbuild - esbuild and rollup behave differently for some exports, and as commented in https://github.com/evanw/esbuild/issues/1182 we can work around this issue with a custom footer to avoid having to change the web-app's way of importing our bundle.
* Enable tsconfig flags which ensures esbuild works and make consequential changes.
* Switch to TypeScript for esbuild
* Run tscbuild and esbuild in parallel