### PR TITLE
feat(ci): Fix race in coveralls, add solidity coverage, check mgv cli, improve dependabot triggers

### DIFF
--- a/.github/workflows/automerge-dependabot-prs.yml
+++ b/.github/workflows/automerge-dependabot-prs.yml
@@ -1,5 +1,8 @@
 name: Dependabot auto-merging
-on: pull_request_target
+on:
+  pull_request_target:
+    branches:
+      - 'dependabot/**'
 permissions:
   pull-requests: write
   contents: write

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -424,10 +424,18 @@ jobs:
       run: yarn mgv help
 
      # == Send coverage report to Coveralls == 
-    - name: Coveralls
+     # Coverallsapp by default uses GITHUB_SHA but that does not necessarily correspond
+     # to HEAD because a branch is checked out. We here find the actual SHA for HEAD.
+    - name: Set Coveralls vars
+      id: coveralls_vars
+      if: github.event_name != 'pull_request_target' 
+      run: echo "::set-output name=sha_for_head::$(git rev-parse HEAD)"
+
+    - name: Upload to Coveralls for mangrove.js
       uses: coverallsapp/github-action@master
       if: github.event_name != 'pull_request_target' 
       with:
+        git-commit: ${{ steps.coveralls_vars.outputs.sha_for_head }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path-to-lcov: ${{env.working-directory}}/coverage/lcov.info
         base-path	: ${{env.working-directory}}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -419,6 +419,10 @@ jobs:
         path: ${{env.working-directory}}/coverage-tests-report.json # Path to test results
         reporter: mocha-json                  # Format of test results
 
+    # == verify cli can start ==
+    - name: Mgv cli Tests
+      run: yarn mgv help
+
      # == Send coverage report to Coveralls == 
     - name: Coveralls
       uses: coverallsapp/github-action@master

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -439,7 +439,25 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path-to-lcov: ${{env.working-directory}}/coverage/lcov.info
         base-path	: ${{env.working-directory}}
-        
+        flag-name: js
+
+    - name: Create coverage report for mangrove-solidity
+      if: github.event_name != 'pull_request_target' 
+      run: forge coverage --report lcov
+      working-directory: . # coverage cannot find contracts if executed inside mangrove-solidity
+      env:
+        POLYGON_NODE_URL: ${{ secrets.POLYGON_NODE_URL }}
+
+    - name: Upload to Coveralls for mangrove-solidity
+      uses: coverallsapp/github-action@master
+      if: github.event_name != 'pull_request_target' 
+      with:
+        git-commit: ${{ steps.coveralls_vars.outputs.sha_for_head }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        path-to-lcov: lcov.info
+        base-path	: .
+        flag-name: solidity
+
     # save artifacts for later stages
     - name: Zip output
       uses: montudor/action-zip@v1

--- a/.github/workflows/update-dependabot-prs.yml
+++ b/.github/workflows/update-dependabot-prs.yml
@@ -2,7 +2,9 @@
 
 name: Update yarn.lock in Dependabot PRs
 on:
-  - pull_request_target
+  pull_request_target:
+    branches:
+      - 'dependabot/**'
 
 jobs:
   fix-lockfile:


### PR DESCRIPTION
* fix(ci): Dependabot workflow should only trigger for select branches
* feat(ci): Verify mgv cli can start as part of checks
* fix(ci): Make coveralls use actual HEAD commit
    * The checkout of the push branch may not actually check out the GITHUB_SHA that triggered the workflow, a newer one may be checked out instead. We retrieve the right one by using git.
* feat(ci): Add solidity code coverage to push trigger
    * Note: we currently run it from the root; otherwise, the coverage reporting cannot find our contracts. This may be related to
https://github.com/foundry-rs/foundry/issues/2915 . Also, we add flags to coveralls in an attempt to separate the reports.