### PR TITLE
liquidity provider from an offerId

### DIFF
--- a/packages/mangrove.js/CHANGELOG.md
+++ b/packages/mangrove.js/CHANGELOG.md
@@ -1,5 +1,7 @@
 # next version
 
+- `market.ts` offers `bid/askProvider` for a specific market offer. This allows one to obtain a `LiquidityProvider` instance connected to the maker contract in charge of a particular offer id.
+
 # 0.10.0 (August 2022)
 
 - Update address for `MangroveOrderEnriched`

--- a/packages/mangrove.js/src/liquidityProvider.ts
+++ b/packages/mangrove.js/src/liquidityProvider.ts
@@ -548,7 +548,6 @@ class LiquidityProvider {
     return this.#approveToken(this.market.quote.name, overrides);
   }
 
-  //TODO handle multi maker case
   async getMissingProvision(
     ba: Market.BA,
     opts: { id?: number; gasreq?: number; gasprice?: number } = {}

--- a/packages/mangrove.js/src/market.ts
+++ b/packages/mangrove.js/src/market.ts
@@ -2,6 +2,7 @@ import * as ethers from "ethers";
 import { BigNumber } from "ethers"; // syntactic sugar
 import Mangrove from "./mangrove";
 import MgvToken from "./mgvtoken";
+import LiquidityProvider from "./liquidityProvider";
 import Semibook from "./semibook";
 import { Bigish, typechain } from "./types";
 import { Deferred } from "./util";
@@ -657,6 +658,26 @@ class Market {
   prettyPrint(ba: Market.BA, filter: prettyPrintFilter): void {
     const offers = this.getSemibook(ba);
     this.prettyP.prettyPrint(offers, filter);
+  }
+
+  /** Returns a liquidity provider API to the contract that manages a given offer */
+  /** This will only make sense is offer maker is a contract */
+  async offerProvider(
+    ba: Market.BA,
+    offerId: number
+  ): Promise<LiquidityProvider> {
+    const offer = await this.offerInfo(ba, offerId);
+    return this.mgv.offerLogic(offer.maker).liquidityProvider(this);
+  }
+
+  async bidProvider(offerId: number): Promise<LiquidityProvider> {
+    const offer = await this.offerInfo("bids", offerId);
+    return this.mgv.offerLogic(offer.maker).liquidityProvider(this);
+  }
+
+  async askProvider(offerId: number): Promise<LiquidityProvider> {
+    const offer = await this.offerInfo("asks", offerId);
+    return this.mgv.offerLogic(offer.maker).liquidityProvider(this);
   }
 
   /**

--- a/packages/mangrove.js/src/offerLogic.ts
+++ b/packages/mangrove.js/src/offerLogic.ts
@@ -31,15 +31,9 @@ class OfferLogic {
   address: string;
   isMultiMaker: boolean;
 
-  constructor(
-    mgv: Mangrove,
-    logic: string,
-    multiMaker: boolean,
-    signer?: SignerOrProvider
-  ) {
+  constructor(mgv: Mangrove, logic: string, signer?: SignerOrProvider) {
     this.mgv = mgv;
     this.address = logic;
-    this.isMultiMaker = multiMaker;
     this.contract = typechain.MultiMaker__factory.connect(
       logic,
       signer ? signer : this.mgv._signer


### PR DESCRIPTION
This PR answers the following use case: signer wishes to post an offer on a market using the maker contract that posted offer `id`. To do so, signer just does:
  1. `lp = await market.bidProvider(id)`
  2. `lp.newAsk({...})`
If the underlying logic is multiMaker then `lp` will be usable by any signer. If the underlying logic is single user, this will only work if signer is also admin.