### PR TITLE
MGV, _MGV and _mgv to mgv in ctors

### DIFF
--- a/packages/mangrove-solidity/script/MangroveJs.s.sol
+++ b/packages/mangrove-solidity/script/MangroveJs.s.sol
@@ -100,7 +100,7 @@ contract MangroveJsDeploy is Deployer {
     ens.set("SimpleTestMaker", address(simpleTestMaker));
 
     vm.broadcast();
-    mgo = new MangroveOrder({_MGV: IMangrove(payable(mgv)), deployer: chief});
+    mgo = new MangroveOrder({mgv: IMangrove(payable(mgv)), deployer: chief});
     ens.set("MangroveOrder", address(mgo));
   }
 }

--- a/packages/mangrove-solidity/script/lib/MangroveDeployer.sol
+++ b/packages/mangrove-solidity/script/lib/MangroveDeployer.sol
@@ -33,11 +33,11 @@ contract MangroveDeployer is Deployer {
     ens.set("Mangrove", address(mgv));
 
     vm.broadcast();
-    reader = new MgvReader({_mgv: payable(mgv)});
+    reader = new MgvReader({mgv: payable(mgv)});
     ens.set("MgvReader", address(reader));
 
     vm.broadcast();
-    cleaner = new MgvCleaner({_MGV: address(mgv)});
+    cleaner = new MgvCleaner({mgv: address(mgv)});
     ens.set("MgvCleaner", address(cleaner));
 
     vm.broadcast();
@@ -46,7 +46,7 @@ contract MangroveDeployer is Deployer {
 
     vm.broadcast();
     mgoe = new MangroveOrderEnriched({
-      _MGV: IMangrove(payable(mgv)),
+      mgv: IMangrove(payable(mgv)),
       deployer: chief
     });
     ens.set("MangroveOrderEnriched", address(mgoe));

--- a/packages/mangrove-solidity/src/periphery/MangroveOrder.sol
+++ b/packages/mangrove-solidity/src/periphery/MangroveOrder.sol
@@ -19,8 +19,8 @@ contract MangroveOrder is PersistentForwarder, IOrderLogic {
   // `blockToLive[token1][token2][offerId]` gives block number beyond which the offer should renege on trade.
   mapping(IERC20 => mapping(IERC20 => mapping(uint => uint))) public expiring;
 
-  constructor(IMangrove _MGV, address deployer)
-    PersistentForwarder(_MGV, new SimpleRouter())
+  constructor(IMangrove mgv, address deployer)
+    PersistentForwarder(mgv, new SimpleRouter())
   {
     set_gasreq(90_000);
     if (deployer != msg.sender) {

--- a/packages/mangrove-solidity/src/periphery/MangroveOrderEnriched.sol
+++ b/packages/mangrove-solidity/src/periphery/MangroveOrderEnriched.sol
@@ -18,7 +18,7 @@ contract MangroveOrderEnriched is MangroveOrder {
   // `next[out_tkn][in_tkn][owner][id] = id'` with `next[out_tkn][in_tkn][owner][0]==0` iff owner has now offers on the semi book (out,in)
   mapping(IERC20 => mapping(IERC20 => mapping(address => mapping(uint => uint)))) next;
 
-  constructor(IMangrove _MGV, address deployer) MangroveOrder(_MGV, deployer) {}
+  constructor(IMangrove mgv, address deployer) MangroveOrder(mgv, deployer) {}
 
   function __logOwnerShipRelation__(
     address owner,

--- a/packages/mangrove-solidity/src/periphery/MgvCleaner.sol
+++ b/packages/mangrove-solidity/src/periphery/MgvCleaner.sol
@@ -59,8 +59,8 @@ interface MangroveLike {
 contract MgvCleaner {
   MangroveLike immutable MGV;
 
-  constructor(address _MGV) {
-    MGV = MangroveLike(_MGV);
+  constructor(address mgv) {
+    MGV = MangroveLike(mgv);
   }
 
   receive() external payable {}

--- a/packages/mangrove-solidity/src/periphery/MgvReader.sol
+++ b/packages/mangrove-solidity/src/periphery/MgvReader.sol
@@ -48,10 +48,10 @@ interface MangroveLike {
 }
 
 contract MgvReader {
-  MangroveLike immutable mgv;
+  MangroveLike immutable MGV;
 
-  constructor(address _mgv) {
-    mgv = MangroveLike(payable(_mgv));
+  constructor(address mgv) {
+    MGV = MangroveLike(payable(mgv));
   }
 
   /*
@@ -71,9 +71,9 @@ contract MgvReader {
   ) public view returns (uint startId, uint length) {
     unchecked {
       if (fromId == 0) {
-        startId = mgv.best(outbound_tkn, inbound_tkn);
+        startId = MGV.best(outbound_tkn, inbound_tkn);
       } else {
-        startId = mgv.offers(outbound_tkn, inbound_tkn, fromId).gives() > 0
+        startId = MGV.offers(outbound_tkn, inbound_tkn, fromId).gives() > 0
           ? fromId
           : 0;
       }
@@ -81,7 +81,7 @@ contract MgvReader {
       uint currentId = startId;
 
       while (currentId != 0 && length < maxOffers) {
-        currentId = mgv.offers(outbound_tkn, inbound_tkn, currentId).next();
+        currentId = MGV.offers(outbound_tkn, inbound_tkn, currentId).next();
         length = length + 1;
       }
 
@@ -121,8 +121,8 @@ contract MgvReader {
 
       while (currentId != 0 && i < length) {
         offerIds[i] = currentId;
-        offers[i] = mgv.offers(outbound_tkn, inbound_tkn, currentId);
-        details[i] = mgv.offerDetails(outbound_tkn, inbound_tkn, currentId);
+        offers[i] = MGV.offers(outbound_tkn, inbound_tkn, currentId);
+        details[i] = MGV.offerDetails(outbound_tkn, inbound_tkn, currentId);
         currentId = offers[i].next();
         i = i + 1;
       }
@@ -162,7 +162,7 @@ contract MgvReader {
       uint i = 0;
       while (currentId != 0 && i < length) {
         offerIds[i] = currentId;
-        (offers[i], details[i]) = mgv.offerInfo(
+        (offers[i], details[i]) = MGV.offerInfo(
           outbound_tkn,
           inbound_tkn,
           currentId
@@ -182,7 +182,7 @@ contract MgvReader {
     uint ofr_gasprice
   ) external view returns (uint) {
     unchecked {
-      (P.Global.t global, P.Local.t local) = mgv.config(
+      (P.Global.t global, P.Local.t local) = MGV.config(
         outbound_tkn,
         inbound_tkn
       );

--- a/packages/mangrove-solidity/src/strategies/MangroveOffer.sol
+++ b/packages/mangrove-solidity/src/strategies/MangroveOffer.sol
@@ -40,8 +40,8 @@ abstract contract MangroveOffer is AccessControlled, IOfferLogic {
   // necessary function to withdraw funds from Mangrove
   receive() external payable virtual {}
 
-  constructor(IMangrove _mgv) AccessControlled(msg.sender) {
-    MGV = _mgv;
+  constructor(IMangrove mgv) AccessControlled(msg.sender) {
+    MGV = mgv;
   }
 
   function ofr_gasreq() public view returns (uint) {

--- a/packages/mangrove-solidity/src/strategies/offer_forwarder/OfferForwarder.sol
+++ b/packages/mangrove-solidity/src/strategies/offer_forwarder/OfferForwarder.sol
@@ -16,8 +16,8 @@ import "mgv_src/strategies/interfaces/IMakerLogic.sol";
 import "mgv_src/strategies/routers/SimpleRouter.sol";
 
 contract OfferForwarder is IMakerLogic, PersistentForwarder {
-  constructor(IMangrove _MGV, address deployer)
-    PersistentForwarder(_MGV, new SimpleRouter())
+  constructor(IMangrove mgv, address deployer)
+    PersistentForwarder(mgv, new SimpleRouter())
   {
     set_gasreq(50_000);
     if (deployer != msg.sender) {

--- a/packages/mangrove-solidity/src/strategies/offer_forwarder/abstract/Forwarder.sol
+++ b/packages/mangrove-solidity/src/strategies/offer_forwarder/abstract/Forwarder.sol
@@ -29,9 +29,9 @@ abstract contract Forwarder is IForwarder, MangroveOffer {
     internal ownerData;
 
   constructor(
-    IMangrove _mgv,
+    IMangrove mgv,
     AbstractRouter _router
-  ) MangroveOffer(_mgv) { // additional gas required for reading `ownerData` at each trade
+  ) MangroveOffer(mgv) { // additional gas required for reading `ownerData` at each trade
     // define `_router` as the liquidity router for `this` and declare that `this` is allowed to call router.
     // NB router also needs to be approved for outbound/inbound token transfers by each user of this contract.
     set_router(_router);

--- a/packages/mangrove-solidity/src/strategies/offer_forwarder/abstract/PersistentForwarder.sol
+++ b/packages/mangrove-solidity/src/strategies/offer_forwarder/abstract/PersistentForwarder.sol
@@ -15,9 +15,9 @@ import "./Forwarder.sol";
 
 abstract contract PersistentForwarder is Forwarder {
   constructor(
-    IMangrove _mgv,
+    IMangrove mgv,
     AbstractRouter _router
-  ) Forwarder(_mgv, _router) {}
+  ) Forwarder(mgv, _router) {}
 
   function __residualWants__(ML.SingleOrder calldata order)
     internal

--- a/packages/mangrove-solidity/src/strategies/offer_maker/OfferMaker.sol
+++ b/packages/mangrove-solidity/src/strategies/offer_maker/OfferMaker.sol
@@ -18,8 +18,8 @@ import "mgv_src/strategies/interfaces/IMakerLogic.sol";
 
 contract OfferMaker is IMakerLogic, Persistent {
 
-  constructor(IMangrove _MGV, AbstractRouter _router, address deployer)
-    Persistent(_MGV, _router) 
+  constructor(IMangrove mgv, AbstractRouter _router, address deployer)
+    Persistent(mgv, _router) 
   {
     set_gasreq(25_000);
     // stores total gas requirement of this strat (depends on router gas requirements)

--- a/packages/mangrove-solidity/src/strategies/offer_maker/abstract/Direct.sol
+++ b/packages/mangrove-solidity/src/strategies/offer_maker/abstract/Direct.sol
@@ -18,9 +18,9 @@ import "mgv_src/strategies/utils/TransferLib.sol";
 /// MangroveOffer is the basic building block to implement a reactive offer that interfaces with the Mangrove
 abstract contract Direct is MangroveOffer {
   constructor(
-    IMangrove _mgv,
+    IMangrove mgv,
     AbstractRouter _router
-  ) MangroveOffer(_mgv) {
+  ) MangroveOffer(mgv) {
     // default reserve is router's address if router is defined
     // if not then default reserve is `this` contract
     if (address(_router) == address(0)) {

--- a/packages/mangrove-solidity/src/strategies/offer_maker/abstract/Persistent.sol
+++ b/packages/mangrove-solidity/src/strategies/offer_maker/abstract/Persistent.sol
@@ -17,9 +17,9 @@ import "./Direct.sol";
 
 abstract contract Persistent is Direct {
   constructor(
-    IMangrove _mgv,
+    IMangrove mgv,
     AbstractRouter _router
-  ) Direct(_mgv, _router) {} // additional gas for reposting offers
+  ) Direct(mgv, _router) {} // additional gas for reposting offers
 
   /** Persistent class specific hooks. */
 

--- a/packages/mangrove-solidity/src/toy_strategies/offer_forwarder/OasisLike.sol
+++ b/packages/mangrove-solidity/src/toy_strategies/offer_forwarder/OasisLike.sol
@@ -15,7 +15,7 @@ import "mgv_src/strategies/offer_forwarder/OfferForwarder.sol";
 import "mgv_src/strategies/routers/SimpleRouter.sol";
 
 contract OasisLike is OfferForwarder {
-  constructor(IMangrove _MGV, address deployer)
-    OfferForwarder(_MGV, deployer)
+  constructor(IMangrove mgv, address deployer)
+    OfferForwarder(mgv, deployer)
   {}
 }

--- a/packages/mangrove-solidity/src/toy_strategies/offer_forwarder/OfferProxy.sol
+++ b/packages/mangrove-solidity/src/toy_strategies/offer_forwarder/OfferProxy.sol
@@ -17,11 +17,11 @@ import "mgv_src/strategies/routers/AaveDeepRouter.sol";
 contract OfferProxy is OfferForwarder {
   constructor(
     address _addressesProvider,
-    IMangrove _MGV,
+    IMangrove mgv,
     address deployer
   )
     OfferForwarder(
-      _MGV,
+      mgv,
       msg.sender
     )
   {

--- a/packages/mangrove-solidity/src/toy_strategies/offer_maker/Ghost.sol
+++ b/packages/mangrove-solidity/src/toy_strategies/offer_maker/Ghost.sol
@@ -22,8 +22,8 @@ abstract contract Ghost is OfferMaker {
     uint offerId2; // id of the offer on stable 2 
     
 
-    constructor(IMangrove _mgv, IERC20 stable1, IERC20 stable2) 
-    OfferMaker(_mgv, new SimpleRouter(), msg.sender) {
+    constructor(IMangrove mgv, IERC20 stable1, IERC20 stable2) 
+    OfferMaker(mgv, new SimpleRouter(), msg.sender) {
         STABLE1 = stable1;
         STABLE2 = stable2;
     }

--- a/packages/mangrove-solidity/src/toy_strategies/offer_maker/cash_management/AdvancedAaveRetail.sol
+++ b/packages/mangrove-solidity/src/toy_strategies/offer_maker/cash_management/AdvancedAaveRetail.sol
@@ -16,10 +16,10 @@ import "mgv_src/strategies/routers/AaveDeepRouter.sol";
 
 contract AdvancedAaveRetail is OfferMaker {
   constructor(
-    IMangrove _mgv,
+    IMangrove mgv,
     address _addressesProvider,
     address deployer
-  ) OfferMaker(_mgv, new AaveDeepRouter(_addressesProvider, 0, 2), deployer) {
+  ) OfferMaker(mgv, new AaveDeepRouter(_addressesProvider, 0, 2), deployer) {
     // Router reserve is by default `router.address`
     // use `set_reserve(addr)` to change this
     router().set_admin(deployer);

--- a/packages/mangrove-solidity/src/toy_strategies/offer_maker/cash_management/SimpleAaveRetail.sol
+++ b/packages/mangrove-solidity/src/toy_strategies/offer_maker/cash_management/SimpleAaveRetail.sol
@@ -16,8 +16,8 @@ import "mgv_src/strategies/routers/AaveRouter.sol";
 
 contract SimpleAaveRetail is OfferMaker {
   constructor(
-    IMangrove _mgv,
+    IMangrove mgv,
     address _addressesProvider,
     address deployer
-  ) OfferMaker(_mgv, new AaveRouter(_addressesProvider, 0, 2), deployer) {}
+  ) OfferMaker(mgv, new AaveRouter(_addressesProvider, 0, 2), deployer) {}
 }

--- a/packages/mangrove-solidity/test/strategies/unit/MakerPermissions.t.sol
+++ b/packages/mangrove-solidity/test/strategies/unit/MakerPermissions.t.sol
@@ -29,7 +29,7 @@ contract MakerPermissionTest is MangroveTest {
     maker = freshAddress("maker");
     deal(maker, 1 ether);
     makerContract = new OfferMaker({
-      _MGV: IMangrove($(mgv)),
+      mgv: IMangrove($(mgv)),
       _router: AbstractRouter(address(0)),
       deployer: maker
     });

--- a/packages/mangrove-solidity/test/strategies/unit/MangroveOffer.t.sol
+++ b/packages/mangrove-solidity/test/strategies/unit/MangroveOffer.t.sol
@@ -41,7 +41,7 @@ contract MangroveOfferTest is MangroveTest {
     deal($(usdc), taker, cash(usdc, 100_000));
 
     makerContract = new OfferMaker({
-      _MGV: IMangrove($(mgv)), 
+      mgv: IMangrove($(mgv)), 
       _router: SimpleRouter(address(0)), // no router
       deployer: maker
     });

--- a/packages/mangrove-solidity/test/strategies/unit/OfferForwarder.t.sol
+++ b/packages/mangrove-solidity/test/strategies/unit/OfferForwarder.t.sol
@@ -8,7 +8,7 @@ import "mgv_src/strategies/offer_forwarder/OfferForwarder.sol";
 contract OfferForwarderTest is OfferLogicTest {
   function setupMakerContract() internal virtual override prank(maker) {
     makerContract = new OfferForwarder({
-      _MGV: IMangrove($(mgv)),  
+      mgv: IMangrove($(mgv)),  
       deployer: maker
     });
     // reserve (which is maker here) approves contract's router

--- a/packages/mangrove-solidity/test/strategies/unit/OfferLogic.t.sol
+++ b/packages/mangrove-solidity/test/strategies/unit/OfferLogic.t.sol
@@ -73,7 +73,7 @@ contract OfferLogicTest is MangroveTest {
   // override this to use MultiUser strats
   function setupMakerContract() internal virtual prank(maker) {
     makerContract = new OfferMaker({
-      _MGV: IMangrove($(mgv)),
+      mgv: IMangrove($(mgv)),
       _router: AbstractRouter(address(0)),
       deployer: maker
     });

--- a/packages/mangrove-solidity/test/toy_strategies/AaveLender.t.sol
+++ b/packages/mangrove-solidity/test/toy_strategies/AaveLender.t.sol
@@ -70,7 +70,7 @@ contract AaveLenderForkedTest is AaveV3ModuleTest {
 
   function deployStrat() public {
     strat = new AdvancedAaveRetail({
-      _mgv: IMangrove($(mgv)),
+      mgv: IMangrove($(mgv)),
       _addressesProvider: fork.AAVE(),
       deployer: $(this)
     });


### PR DESCRIPTION
IMHO MGV and _MGV should be changed to be mixedCase. I am a bit unsure whether _mgv should stay and be applied all over. We seem to use a mix of _ and not for parameter names. I see, e.g., https://ethereum.stackexchange.com/questions/56443/what-does-mean-before-a-variable-name mentions that some do it for all parameters to avoid shadowing. We currently do it when there are collisions but also sometimes when there is not.

I have not changed all tests.