### PR TITLE
fix(doc): offer book -> order book

### DIFF
--- a/packages/mangrove-solidity/preprocessing/structs.js
+++ b/packages/mangrove-solidity/preprocessing/structs.js
@@ -1,5 +1,5 @@
 /* # Mangrove Summary
-   * The Mangrove holds offer books for `outbound_tkn`,`inbound_tkn` pairs.
+   * The Mangrove holds order books for `outbound_tkn`,`inbound_tkn` pairs.
    * Offers are sorted in a doubly linked list.
    * Each offer promises `outbound_tkn` and requests `inbound_tkn`.
    * Each offer has an attached `maker` address.

--- a/packages/mangrove-solidity/src/MgvOfferMaking.sol
+++ b/packages/mangrove-solidity/src/MgvOfferMaking.sol
@@ -107,7 +107,7 @@ contract MgvOfferMaking is MgvHasOffers {
   //+clear+
   /* Very similar to `newOffer`, `updateOffer` prepares an `OfferPack` for `writeOffer`. Makers should use it for updating live offers, but also to save on gas by reusing old, already consumed offers.
 
-     A `pivotId` should still be given to minimise reads in the offer book. It is OK to give the offers' own id as a pivot.
+     A `pivotId` should still be given to minimise reads in the order book. It is OK to give the offers' own id as a pivot.
 
 
      Gas use is minimal when:

--- a/packages/mangrove-solidity/src/periphery/MangroveOrder.sol
+++ b/packages/mangrove-solidity/src/periphery/MangroveOrder.sol
@@ -233,8 +233,8 @@ contract MangroveOrder is PersistentForwarder, IOrderLogic {
   /**
   @notice This is invoked for each new offer created for resting orders, e.g., to maintain an inverse mapping from owner to offers.
   @param owner the owner of the offer new offer
-  @param outbound_tkn the outbound token used to identify the offer book
-  @param inbound_tkn the inbound token used to identify the offer book
+  @param outbound_tkn the outbound token used to identify the order book
+  @param inbound_tkn the inbound token used to identify the order book
   @param offerId the id of the new offer
   */
   function __logOwnershipRelation__(

--- a/packages/mangrove-solidity/test/core/MakerOperations.t.sol
+++ b/packages/mangrove-solidity/test/core/MakerOperations.t.sol
@@ -506,7 +506,7 @@ contract MakerOperationsTest is MangroveTest, IMaker {
     assertEq(ofr0, cfg.best(), "Wrong best offer");
     mkr.updateOffer(1.0 ether, 1.0 ether, 99_999, ofr1, ofr1);
     (, cfg) = mgv.config($(base), $(quote));
-    logOfferBook($(base), $(quote), 2);
+    logOrderBook($(base), $(quote), 2);
     assertEq(cfg.best(), ofr1, "Best offer should have changed");
   }
 
@@ -529,7 +529,7 @@ contract MakerOperationsTest is MangroveTest, IMaker {
     assertEq(ofr0, cfg.best(), "Wrong best offer");
     mkr.updateOffer(1.0 ether, 1.0 ether, 99_999, ofr0, ofr1);
     (, cfg) = mgv.config($(base), $(quote));
-    logOfferBook($(base), $(quote), 2);
+    logOrderBook($(base), $(quote), 2);
     assertEq(cfg.best(), ofr1, "Best offer should have changed");
   }
 

--- a/packages/mangrove-solidity/test/core/Scenarii.t.sol
+++ b/packages/mangrove-solidity/test/core/Scenarii.t.sol
@@ -98,7 +98,7 @@ contract ScenariiTest is MangroveTest {
     );
 
     snipe();
-    logOfferBook($(base), $(quote), 4);
+    logOrderBook($(base), $(quote), 4);
 
     // restore offer that was deleted after partial fill, minus taken amount
     makers.getMaker(2).updateOffer(
@@ -109,17 +109,17 @@ contract ScenariiTest is MangroveTest {
       2
     );
 
-    logOfferBook($(base), $(quote), 4);
+    logOrderBook($(base), $(quote), 4);
 
     saveBalances();
     saveOffers();
     mo();
-    logOfferBook($(base), $(quote), 4);
+    logOrderBook($(base), $(quote), 4);
 
     saveBalances();
     saveOffers();
     collectFailingOffer(offerOf[0]);
-    logOfferBook($(base), $(quote), 4);
+    logOrderBook($(base), $(quote), 4);
     saveBalances();
     saveOffers();
   }
@@ -412,6 +412,6 @@ contract DeepCollectTest is MangroveTest {
 
   function moWithFailures() internal {
     tkr.marketOrderWithFail({wants: 10 ether, gives: 30 ether});
-    assertTrue(isEmptyOB($(base), $(quote)), "Offer book should be empty");
+    assertTrue(isEmptyOB($(base), $(quote)), "Order book should be empty");
   }
 }

--- a/packages/mangrove-solidity/test/lib/MangroveTest.sol
+++ b/packages/mangrove-solidity/test/lib/MangroveTest.sol
@@ -92,7 +92,7 @@ contract MangroveTest is Test2, HasMgvEvents {
     quote.approve($(mgv), type(uint).max);
   }
 
-  /* Log offer book */
+  /* Log order book */
 
   event OBState(
     address base,
@@ -106,9 +106,9 @@ contract MangroveTest is Test2, HasMgvEvents {
 
   /** Two different OB logging methods.
    *
-   *  `logOfferBook` will be easy to read in traces
+   *  `logOrderBook` will be easy to read in traces
    *
-   *  `printOfferBook` will be easy to read in the console.logs section
+   *  `printOrderBook` will be easy to read in the console.logs section
    */
 
   /* Log OB with events */
@@ -121,7 +121,7 @@ contract MangroveTest is Test2, HasMgvEvents {
     uint gasreq
   );
 
-  function logOfferBook(
+  function logOrderBook(
     address $out,
     address $in,
     uint size
@@ -156,7 +156,7 @@ contract MangroveTest is Test2, HasMgvEvents {
   }
 
   /* Log OB with console */
-  function printOfferBook(address $out, address $in) internal view {
+  function printOrderBook(address $out, address $in) internal view {
     uint offerId = mgv.best($out, $in);
     TestToken req_tk = TestToken($in);
     TestToken ofr_tk = TestToken($out);


### PR DESCRIPTION
We mostly stick to using order book for our books with bids and aks. However, in some places we used offer book instead. We now use order book everywhere.