### PR TITLE
Run ci/1

### DIFF
--- a/.github/actions/foundry-setup/action.yml
+++ b/.github/actions/foundry-setup/action.yml
@@ -9,6 +9,7 @@ runs:
       version: nightly
     
   - name: Show Foundry version
+    shell: bash
     run: forge --version
 
   - name: Get Foundry RPC cache

--- a/.github/actions/foundry-setup/action.yml
+++ b/.github/actions/foundry-setup/action.yml
@@ -7,6 +7,9 @@ runs:
     uses: foundry-rs/foundry-toolchain@v1
     with:
       version: nightly
+    
+  - name: Show Foundry version
+    run: forge --version
 
   - name: Get Foundry RPC cache
     uses: actions/cache@v3
@@ -20,9 +23,8 @@ runs:
     uses: actions/cache@v3
     with:
       path: |
-        ${{ format('{0}/cache',env.working-directory) }}
-        ${{ format('{0}/out', env.working-directory) }}
-      key: foundry-build-cache-${{ hashFiles('foundry.toml',format('${0}/[lib,script,src,test]/',env.working-directory)) }}
+        packages/mangrove-solidity/cache
+        packages/mangrove-solidity/out
+      key: foundry-build-cache-${{ hashFiles('foundry.toml',format('${0}/[lib,script,src,test]/','packages/mangrove-solidity')) }}
       restore-keys: |
         foundry-build-cache-
-    


### PR DESCRIPTION
Loads build cache no matter the working directory, and show foundry version for debugging purposes.