### PR TITLE
refactor(mangrove.js): Rename penalty to bounty in Market.Summary

### DIFF
--- a/packages/bot-failing-offer/test/integration/failingOffer.integration.test.ts
+++ b/packages/bot-failing-offer/test/integration/failingOffer.integration.test.ts
@@ -143,6 +143,6 @@ describe("Failing offer integration tests", () => {
 
     // Assert
     assert.equal(0, cleanerMarket.getSemibook("asks").size());
-    assert.equal(result !== undefined && result.summary.penalty.gt(0), true);
+    assert.equal(result !== undefined && result.summary.bounty.gt(0), true);
   });
 });

--- a/packages/bot-taker-greedy/src/OfferTaker.ts
+++ b/packages/bot-taker-greedy/src/OfferTaker.ts
@@ -271,7 +271,7 @@ export class OfferTaker {
             gave: result.summary.gave.toString(),
             got: result.summary.got.toString(),
             partialFill: result.summary.partialFill,
-            penalty: result.summary.penalty.toString(),
+            penalty: result.summary.bounty.toString(),
           },
         },
       });

--- a/packages/mangrove.js/CHANGELOG.md
+++ b/packages/mangrove.js/CHANGELOG.md
@@ -1,5 +1,7 @@
 # next version
 
+- Rename `penalty` to `bounty` in `Market.Summary` as it's a bounty from the taker's perspective
+
 # 0.11.1 (October 2022)
 
 - Fixed decimals handling for resting order in results.

--- a/packages/mangrove.js/src/market.ts
+++ b/packages/mangrove.js/src/market.ts
@@ -49,7 +49,7 @@ namespace Market {
     got: Big;
     gave: Big;
     partialFill: boolean;
-    penalty: Big;
+    bounty: Big;
     feePaid: Big;
   };
   export type OrderResult = {

--- a/packages/mangrove.js/src/util/tradeEventManagement.ts
+++ b/packages/mangrove.js/src/util/tradeEventManagement.ts
@@ -92,7 +92,7 @@ class TradeEventManagement {
         event.args.takerGot.add(event.args.feePaid ?? ethers.BigNumber.from(0)),
         event.args.takerGave
       ),
-      penalty: this.mangroveUtils.fromUnits(event.args.penalty, 18),
+      bounty: this.mangroveUtils.fromUnits(event.args.penalty, 18),
       feePaid:
         "feePaid" in event.args
           ? this.mangroveUtils.fromUnits(event.args.feePaid, 18)

--- a/packages/mangrove.js/test/integration/market.integration.test.ts
+++ b/packages/mangrove.js/test/integration/market.integration.test.ts
@@ -711,7 +711,7 @@ describe("Market integration tests suite", () => {
       utils.parseBytes32String(result.tradeFailures[0].reason)
     ).to.be.equal("mgv/makerTransferFail");
     expect(result.successes).to.have.lengthOf(0);
-    expect(result.summary.penalty.toNumber()).to.be.greaterThan(0);
+    expect(result.summary.bounty.toNumber()).to.be.greaterThan(0);
     //expect(result.failures[0].offerId).to.be.equal(1);
 
     const offerEvent = await queue.get();
@@ -1066,7 +1066,7 @@ describe("Market integration tests suite", () => {
       expect(result.summary.got.toNumber()).to.be.equal(0);
       expect(result.summary.gave.toNumber()).to.be.equal(0);
 
-      expect(result.summary.penalty.toNumber()).to.be.equal(0.00009591);
+      expect(result.summary.bounty.toNumber()).to.be.equal(0.00009591);
       expect(result.summary.feePaid.toNumber()).to.be.equal(0);
 
       // Verify book gets updated to reflect offers have failed and are removed

--- a/packages/mangrove.js/test/integration/restingOrder.integration.test.ts
+++ b/packages/mangrove.js/test/integration/restingOrder.integration.test.ts
@@ -128,7 +128,7 @@ describe("RestingOrder", () => {
         orderResult.summary.partialFill,
         "Order should have been partially filled"
       );
-      assert(orderResult.summary.penalty.eq(0), "No offer should have failed");
+      assert(orderResult.summary.bounty.eq(0), "No offer should have failed");
     });
 
     it("resting order with deadline", async () => {
@@ -185,7 +185,7 @@ describe("RestingOrder", () => {
         "Timestamp did not advance"
       );
       const result_ = await market.sell({ wants: 5, gives: 5 });
-      assert(result_.summary.penalty.gt(0), "Order should have reneged");
+      assert(result_.summary.bounty.gt(0), "Order should have reneged");
     });
   });
 });

--- a/packages/mangrove.js/test/unit/tradeEventManagement.unit.test.ts
+++ b/packages/mangrove.js/test/unit/tradeEventManagement.unit.test.ts
@@ -63,7 +63,7 @@ describe("TradeEventManagement unit tests suite", () => {
       assert.equal(result.got, expectedGot);
       assert.equal(result.gave, expectedGave);
       assert.equal(result.partialFill, true);
-      assert.equal(result.penalty, expectedPenalty);
+      assert.equal(result.bounty, expectedPenalty);
       assert.equal(result.feePaid, expectedFeePaid);
     });
   });
@@ -122,7 +122,7 @@ describe("TradeEventManagement unit tests suite", () => {
         got: Big(1),
         gave: Big(2),
         partialFill: false,
-        penalty: Big(3),
+        bounty: Big(3),
         feePaid: Big(4),
       };
       const expectedOfferId = BigNumber.from(20);
@@ -159,7 +159,7 @@ describe("TradeEventManagement unit tests suite", () => {
       assert.equal(result.got, summary.got);
       assert.equal(result.gave, summary.gave);
       assert.equal(result.partialFill, summary.partialFill);
-      assert.equal(result.penalty, summary.penalty);
+      assert.equal(result.bounty, summary.bounty);
     });
   });
 


### PR DESCRIPTION
It's a bounty from the taker's (who's buying or selling) perspective, so makes more sense to call it that.