### PR TITLE
fix(restingOrder): addresses had inconsistent casing

### DIFF
--- a/packages/mangrove.js/src/constants.ts
+++ b/packages/mangrove.js/src/constants.ts
@@ -2,10 +2,19 @@ import addressesPerNetwork from "./constants/addresses.json";
 import tokenDecimals from "./constants/tokenDecimals.json";
 import tokenDisplayedDecimals from "./constants/tokenDisplayedDecimals.json";
 import tokenDisplayedAsPriceDecimals from "./constants/tokenDisplayedAsPriceDecimals.json";
+import { ethers } from "ethers";
 
-export const addresses = {
-  ...addressesPerNetwork,
-};
+const addresses = { ...addressesPerNetwork };
+
+for (const [network, networkAddresses] of Object.entries(addresses)) {
+  for (const [name, address] of Object.entries(networkAddresses) as any) {
+    if (address) {
+      addresses[network][name] = ethers.utils.getAddress(address);
+    }
+  }
+}
+
+export { addresses };
 
 export const EOA_offer_gasreq = 5000;
 

--- a/packages/mangrove.js/src/mangrove.ts
+++ b/packages/mangrove.js/src/mangrove.ts
@@ -385,6 +385,7 @@ class Mangrove {
     if (!Mangrove.addresses[network]) {
       Mangrove.addresses[network] = {};
     }
+    address = ethers.utils.getAddress(address);
     Mangrove.addresses[network][name] = address;
   }
 

--- a/packages/mangrove.js/src/util/toyEnsEntries.ts
+++ b/packages/mangrove.js/src/util/toyEnsEntries.ts
@@ -12,18 +12,26 @@ export const getAllToyENSEntries = async (
   const [names, addresses] = await ens.all();
 
   /* Grab decimals for all contracts */
-  const decFn = (new ethers.utils.Interface(["function decimals() view returns (uint8)"]));
-  const decimalsData = decFn.encodeFunctionData("decimals",[]);
-  const args = addresses.map(addr => [addr, decimalsData]);
-  const multicall = new ethers.Contract(Multicall.address, Multicall.abi, provider);
-  const [allIsToken,allDecimals] = await multicall.callStatic.aggregate(args);
+  const decFn = new ethers.utils.Interface([
+    "function decimals() view returns (uint8)",
+  ]);
+  const decimalsData = decFn.encodeFunctionData("decimals", []);
+  const args = addresses.map((addr) => [addr, decimalsData]);
+  const multicall = new ethers.Contract(
+    Multicall.address,
+    Multicall.abi,
+    provider
+  );
+  const [allIsToken, allDecimals] = await multicall.callStatic.aggregate(args);
 
   const contracts = names.map((name, index) => {
     let decimals;
     if (allIsToken[index]) {
-      decimals = decFn.decodeFunctionResult("decimals",allDecimals[index])[0];
+      decimals = decFn.decodeFunctionResult("decimals", allDecimals[index])[0];
     }
-    return { name, address: addresses[index], decimals };
+
+    // we lower case addresses here to ensure we store and compare checksum cased addresses
+    return { name, address: addresses[index].toLowerCase(), decimals };
   });
   return contracts;
 };


### PR DESCRIPTION
We have some addresses on addresses.json with non-checksum casing.

We now store them with checksum casing so that comparisons can be done case-sensitive.