### PR TITLE
Revert "build(deps-dev): Bump chalk from 4.1.2 to 5.0.1"

### DIFF
--- a/packages/mangrove.js/package.json
+++ b/packages/mangrove.js/package.json
@@ -87,7 +87,7 @@
     "@typescript-eslint/parser": "^5.22.0",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",
-    "chalk": "^5.0.1",
+    "chalk": "^4.1.2",
     "cross-env": "^7.0.3",
     "dir-compare": "^4.0.0",
     "esbuild": "^0.15.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1783,7 +1783,7 @@ __metadata:
     big.js: ^6.1.1
     chai: ^4.3.6
     chai-as-promised: ^7.1.1
-    chalk: ^5.0.1
+    chalk: ^4.1.2
     cross-env: ^7.0.3
     dir-compare: ^4.0.0
     esbuild: ^0.15.6
@@ -2867,20 +2867,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.1.0":
+"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
     ansi-styles: ^4.1.0
     supports-color: ^7.1.0
   checksum: fe75c9d5c76a7a98d45495b91b2172fa3b7a09e0cc9370e5c8feb1c567b85c4288e2b3fded7cfdd7359ac28d6b3844feb8b82b8686842e93d23c827c417e83fc
-  languageName: node
-  linkType: hard
-
-"chalk@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "chalk@npm:5.0.1"
-  checksum: 7b45300372b908f0471fbf7389ce2f5de8d85bb949026fd51a1b95b10d0ed32c7ed5aab36dd5e9d2bf3191867909b4404cef75c5f4d2d1daeeacd301dd280b76
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reverts mangrovedao/mangrove#649 as this upgrade requires code changes in mangrove.js